### PR TITLE
Change color in editor: Grey -> Gray

### DIFF
--- a/gui-lib/mred/private/editor.rkt
+++ b/gui-lib/mred/private/editor.rkt
@@ -756,7 +756,7 @@
                   '("Top" "Center" "Bottom")
                   '(top center bottom))
 
-        (let ([colors '("Black" "White" "Red" "Orange" "Yellow" "Green" "Blue" "Purple" "Cyan" "Magenta" "Grey")])
+        (let ([colors '("Black" "White" "Red" "Orange" "Yellow" "Green" "Blue" "Purple" "Cyan" "Magenta" "Gray")])
 
                                         ; Colors
           (for-each (lambda (c)


### PR DESCRIPTION
I'm not sure that this is an error, because I couldn't trigger it. 
 
I suspect that this "Grey" color is ignored or silently transformed to RGB=#000. The other colors in the list are in the default color database, but this isn't. 
