### PR TITLE
Use object=? instead of eq? to handle equality for contracted objects

### DIFF
--- a/gui-lib/mred/private/wxme/pasteboard.rkt
+++ b/gui-lib/mred/private/wxme/pasteboard.rkt
@@ -237,7 +237,10 @@
                              ;; find snip:
                              (let ([snip (find-snip x y)])
                                (and snip
-                                    (eq? snip s-caret-snip)
+                                    (or (and (object? snip)
+                                             (object? s-caret-snip)
+                                             (object=? snip s-caret-snip))
+                                        (eq? snip s-caret-snip))
                                     (let-boxes ([x 0.0] [y 0.0])
                                         (get-snip-location snip x y)
                                       (let ([c (send snip adjust-cursor dc (- x scrollx) (- y scrolly) 
@@ -260,7 +263,7 @@
                         (values dc (+ x scrollx) (+ y scrolly) scrollx scrolly)))])
         (let ([snip (find-snip x y)])
           (when (and prev-mouse-snip
-                     (not (eq? snip prev-mouse-snip)))
+                     (not (object=? snip prev-mouse-snip)))
             (let ([loc (snip->loc prev-mouse-snip)])
               (send prev-mouse-snip on-event
                     dc (- (loc-x loc) scrollx) (- (loc-y loc) scrolly) 
@@ -269,7 +272,7 @@
           (set! prev-mouse-snip #f)
           (when (and snip
                      (has-flag? (snip->flags snip) HANDLES-ALL-MOUSE-EVENTS)
-                     (not (eq? snip s-caret-snip)))
+                     (not (object=? snip s-caret-snip)))
             (let ([loc (snip->loc snip)])
               (set! prev-mouse-snip snip)
               (send snip on-event
@@ -278,7 +281,7 @@
                     event)))
           (if (and s-caret-snip
                    (or (not (send event button-down?))
-                       (eq? snip s-caret-snip)))
+                       (object=? snip s-caret-snip)))
               (let ([loc (snip->loc s-caret-snip)])
                 (send s-caret-snip on-event
                       dc (- (loc-x loc) scrollx) (- (loc-y loc) scrolly) 
@@ -667,8 +670,8 @@
               (set-snip-loc! snip loc)
             
               (set-snip-style! snip (send s-style-list convert (snip->style snip)))
-              (when (eq? (snip->style snip)
-                         (send s-style-list basic-style))
+              (when (object=? (snip->style snip)
+                              (send s-style-list basic-style))
                 (let ([s (get-default-style)])
                   (when s
                     (set-snip-style! snip s))))
@@ -1098,11 +1101,15 @@
       ;; lock during set-admin! [???]
       (send snip set-admin a)
 
-      (if (not (eq? (send snip get-admin) a))
+      (if (not (let ([ad (send snip get-admin)])
+                 (or (and (object? ad) (object? a) (object=? ad a))
+                     (eq? ad a))))
           ;; something went wrong
           (cond
            [(and (not a)
-                 (eq? (snip->admin snip) orig-admin))
+                 (let ([ad (snip->admin snip)])
+                   (or (and (object? ad) (object? orig-admin) (object=? ad orig-admin))
+                       (eq? ad orig-admin))))
             ;; force admin to null
             (set-snip-admin! snip #f)
             snip]
@@ -1248,7 +1255,10 @@
                         
                         (send snip draw
                               dc x y dcx dcy dcr dcb dx dy 
-                              (if (eq? snip s-caret-snip)
+                              (if (or (and (object? snip)
+                                           (object? s-caret-snip)
+                                           (object=? snip s-caret-snip))
+                                      (eq? snip s-caret-snip))
                                   show-caret
                                   'no-caret))
 
@@ -1799,7 +1809,8 @@
         (do-buffer-paste cb time #f)
         
         (if (and s-admin
-                 (not (eq? snips start)))
+                 (not (or (and (object? snips) (object? start) (object=? snips start))
+                          (eq? snips start))))
             (let ([dc (get-dc)])
               (when dc
                 ;; get top/left/bottom/right of pasted group:
@@ -1808,7 +1819,8 @@
                            [top +inf.0]
                            [right -inf.0]
                            [bottom -inf.0])
-                  (if (eq? snip start)
+                  (if (or (and (object? snip) (object? start) (object=? snip start))
+                          (eq? snip start))
                       (let ([dx (- cx (/ (+ left right) 2))]
                             [dy (- cy (/ (+ top bottom) 2))])
                         ;; shift the pasted group to center:
@@ -1824,7 +1836,8 @@
                               (max (loc-b loc) bottom)))))))
             ;; just select them:
             (let loop ([snip snips])
-              (unless (eq? snip start)
+              (unless (or (and (object? snip) (object? start) (object=? snip start))
+                          (eq? snip start))
                 (add-selected snip)
                 (loop (snip->next snip))))))))
 


### PR DESCRIPTION
This pull requests changes several instances of `eq?` in the pasteboard implementation to instead use `object=?` allowing for contracted objects to be compared, and improving interop with typed racket programs using pasteboards.