### PR TITLE
Delete Trailing whitespace on return

### DIFF
--- a/gui-doc/scribblings/framework/racket.scrbl
+++ b/gui-doc/scribblings/framework/racket.scrbl
@@ -86,6 +86,7 @@
   @defmethod*[(((insert-return) void?))]{
     Inserts a newline into the buffer.  If @method[racket:text<%>
     tabify-on-return?] returns @racket[#t], this will tabify the new line.
+    Deletes any trailing whitespace from the old line.
   }
 
   @defmethod*[(((box-comment-out-selection


### PR DESCRIPTION
This deletes trailing whitespace from the current line when you press return. Should eliminate a lot of accidental whitespace.

I also added tests for `insert-return` with the ability to specify `tabify-on-return?`, but I didn't add any tests where `tabify-on-result?` was `#f` since I couldn't figure out test cases that actually depended on that value.