### PR TITLE
win32 support for frame% fullscreen and is-fullscreened?

### DIFF
--- a/gui-doc/scribblings/gui/frame-class.scrbl
+++ b/gui-doc/scribblings/gui/frame-class.scrbl
@@ -124,7 +124,7 @@ See also @method[frame% set-status-text].
            void?]{
 
 Puts the frame in fullscreen mode or restores the frame to
- non-fullscreen mode (Mac OS X).
+ non-fullscreen mode (Mac OS X, Windows).
 
 @Unmonitored[@elem{A frame's mode} @elem{the user} @elem{a
 frame has been put in fullscreen mode} @elem{@method[frame% is-fullscreened?]}]
@@ -163,7 +163,7 @@ frame has been iconized} @elem{@method[frame% is-iconized?]}]
 @defmethod[(is-fullscreened?)
            boolean?]{
 
-Returns @racket[#t] if the frame is in fullscreen mode (Mac OS X), @racket[#f]
+Returns @racket[#t] if the frame is in fullscreen mode (Mac OS X, Windows), @racket[#f]
 otherwise.
 
 @history[#:added "6.0.0.6"]

--- a/gui-lib/mred/private/wx/win32/const.rkt
+++ b/gui-lib/mred/private/wx/win32/const.rkt
@@ -347,6 +347,7 @@
                                         QS_HOTKEY
                                         QS_SENDMESSAGE))
 
+(define GWL_STYLE           -16)
 (define GWLP_WNDPROC        -4)
 (define GWLP_USERDATA       -21)
 


### PR DESCRIPTION
This has a bit more to it than the gtk fullscreen commit (#8), which is why I left it separate.

I referred to, and basically translated, the way that GTK performs fullscreen/unfullscreening on win32:
https://github.com/GNOME/gtk/blob/bbac0eb3b938769d450310022ab7d5e8109525e4/gdk/win32/gdkwindow-win32.c#L2813

tested on a three monitor win7 64bit machine, as that's all i can test this on.

happy to do any followup work that it needs.