### PR TITLE
Use a regular expression to indent for loops in framework

### DIFF
--- a/gui-lib/framework/private/main.rkt
+++ b/gui-lib/framework/private/main.rkt
@@ -415,8 +415,6 @@
                splicing-letrec-syntaxes splicing-letrec-syntaxes+values
                splicing-local splicing-syntax-parameterize
 
-               ,@all-fors
-
                do:
                
                kernel-syntax-case
@@ -447,7 +445,7 @@
                type-case))
   (preferences:set-default 
    'framework:tabify
-   (list defaults-ht #rx"^begin" #rx"^def" #f #f)
+   (list defaults-ht #rx"^begin" #rx"^def" #rx"^for\\*?(/|$)" #f)
    (list/c (hash/c symbol? (or/c 'for/fold 'define 'begin 'lambda) #:flat? #t)
            (or/c #f regexp?) (or/c #f regexp?) (or/c #f regexp?) (or/c #f regexp?)))
   

--- a/gui-test/framework/tests/racket.rkt
+++ b/gui-test/framework/tests/racket.rkt
@@ -142,6 +142,16 @@
 (test-indentation "(lambdaa (x)\nb)" "(lambdaa (x)\n         b)")
 (test-indentation "(define x\n  (let/ec return\n    (when 1\n      (when 2\n\t\t      3))\n    2))"
                   "(define x\n  (let/ec return\n    (when 1\n      (when 2\n        3))\n    2))")
+(test-indentation "(for ([x 1])\nx)"
+                  "(for ([x 1])\n  x)")
+(test-indentation "(for/list ([x 1])\nx)"
+                  "(for/list ([x 1])\n  x)")
+(test-indentation "(for/anything ([x 1])\nx)"
+                  "(for/anything ([x 1])\n  x)")
+(test-indentation "(for*/anything ([x 1])\nx)"
+                  "(for*/anything ([x 1])\n  x)")
+(test-indentation "(for-anything ([x 1])\nx)"
+                  "(for-anything ([x 1])\n              x)")
 (test-indentation "(for/fold ([x 1])\n([y 2])\n3\n4)"
                   "(for/fold ([x 1])\n          ([y 2])\n  3\n  4)")
 (test-indentation "a\na\na\n" "a\na\na\n")


### PR DESCRIPTION
The list of for loops is growing quite long, and as I add more, I'm beginning to grow a little bit frustrated that I need to add each new loop form to the list. Furthermore, there is no way to distribute these indentation settings with my package, so every user would need to set them for themselves.

This simply adds the regex `^for\*?(/|$)` to include all for loops, both built-in and user-defined. With this change, manually including the zoo of for loops in the indentation list is unnecessary, cleaning it up considerably.