### PR TITLE
Parenthesis color scheme default to "Spring"

### DIFF
--- a/gui-lib/framework/private/main.rkt
+++ b/gui-lib/framework/private/main.rkt
@@ -85,7 +85,7 @@
                                     l))
                              values)
 
-(preferences:set-default 'framework:paren-color-scheme 'basic-grey symbol?)
+(preferences:set-default 'framework:paren-color-scheme 'spring symbol?)
   
 (define cond/offset-defaults
   '(("case-lambda" 0)


### PR DESCRIPTION
Change default to one that highlights nested structure, i.e. anything but the current "Basic grey".
As the default for a new user, "Spring" has these advantages:
   - lightest (versus "Shades of grey" or "Fall")
   - emphasizes outer structure more than inner (e.g. versus "Winter")
   - doesn't suggest selection (e.g. versus "Shades of blue"), instead it suggests yellow highlighting