### PR TITLE
Fix racket:text-mixin docs to include required editor:keymap<%> inter…

### DIFF
--- a/gui-doc/scribblings/framework/racket.scrbl
+++ b/gui-doc/scribblings/framework/racket.scrbl
@@ -258,7 +258,7 @@
   }
 }
 @defmixin[racket:text-mixin
-          (text:basic<%> mode:host-text<%> color:text<%> text:autocomplete<%>)
+          (text:basic<%> mode:host-text<%> color:text<%> text:autocomplete<%> editor:keymap<%>)
           (racket:text<%>)]{
   This mixin adds functionality for editing Racket files.
 


### PR DESCRIPTION
…face

This seems to be required since this mixin application:

```
(racket:text-mixin
   (color:text-mixin
     (text:basic-mixin
      (editor:basic-mixin
       (mode:host-text-mixin
        (text:autocomplete-mixin
         text%))))))
```
Gives the error:
```
text-mixin: argument class does not implement interface
  argument: #<class:...rk/private/color.rkt:84:2>
  interface name: #<interface:editor:keymap<%>>
```