### PR TITLE
Fixes bug in slider%

### DIFF
--- a/gui-lib/mred/private/wx/cocoa/slider.rkt
+++ b/gui-lib/mred/private/wx/cocoa/slider.rkt
@@ -164,7 +164,8 @@
     (flip (inexact->exact (floor (tell #:type _double slider-cocoa doubleValue)))))
 
   (define/public (update-message [val (get-value)])
-    (tellv message-cocoa setStringValue: #:type _NSString (format "~a" val)))
+    (tellv message-cocoa setStringValue: #:type _NSString (format "~a" val))
+    (tellv message-cocoa sizeToFit))
 
   (inherit get-cocoa-window)
   (define/override (post-mouse-down)


### PR DESCRIPTION
It would occasionally drop the last digit in the message field.

This turned out to be a bug where the number, while smaller, was wider.
For example:
11111
10101

In variable width fonts the second one will be wider