### PR TITLE
fix DrRacket internal error: replace-all with empty str [needs-review]

### DIFF
--- a/gui-lib/framework/private/frame.rkt
+++ b/gui-lib/framework/private/frame.rkt
@@ -2370,7 +2370,11 @@
     (define/override (edit-menu:create-find-case-sensitive?) #t)
 
     (define/override (edit-menu:replace-all-callback menu evt) (replace-all) #t)
-    (define/override (edit-menu:replace-all-on-demand item) (send item enable (not hidden?)))
+    (define/override (edit-menu:replace-all-on-demand item)
+      (send item enable (and find-edit
+                             (not (string=? (send find-edit get-text) ""))
+                             (not hidden?)
+                             replace-visible?)))
     (define/override (edit-menu:create-replace-all?) #t)
 
     (define/override make-root-area-container


### PR DESCRIPTION
This PR fixes an internal error in DrRacket (reproduced in Windows and Linux) but I'm unsure if I changed the right code.

The following sequence produces the error:
1) Edit -> Find
2) make sure search box is empty
3) Edit -> Replace All

I added a guard in `replace-all` in `gui-lib/framework/private/frame.rkt`.

However, the error comes from `do-find-string` in https://github.com/racket/gui/blob/master/gui-lib/mred/private/wxme/text.rkt#L3780, which seems assume a non-empty string input, but I guessed that this is intended since the function seems to be called from many sources and I was unable to produce the error from these other paths. (Although the non-empty string requirement should be documented in the public methods.)

Did I change the right code?

The full error output is:
```
string-ref: index is out of range for empty string
  index: 0
  context...:
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/mred/private/wxme/text.rkt:3660:2: do-find-string method in text%
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/framework/private/search.rkt:29:4: loop
   ...ow-val-first.rkt:306:25
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/framework/private/frame.rkt:2526:12: loop
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/framework/private/frame.rkt:2518:4: replace-all method in ...rk/private/frame.rkt:2307:2
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/framework/private/frame.rkt:2372:4: edit-menu:replace-all-callback method in ...rk/private/frame.rkt:2307:2
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/mred/private/mrmenu.rkt:250:14: command method in basic-selectable-menu-item%
   /home/stchang/plt-stchang/racket/collects/racket/private/more-scheme.rkt:148:2: call-with-break-parameterization
   /home/stchang/plt-stchang/racket/collects/ffi/unsafe/atomic.rkt:72:13
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/mred/private/wx/common/queue.rkt:454:6
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/mred/private/wx/common/queue.rkt:505:32
   /home/stchang/plt-stchang/extra-pkgs/gui/gui-lib/mred/private/wx/common/queue.rkt:653:3
```

