### PR TITLE
make GdkCursor nullable

### DIFF
--- a/gui-lib/mred/private/wx/gtk/cursor.rkt
+++ b/gui-lib/mred/private/wx/gtk/cursor.rkt
@@ -36,7 +36,7 @@
                 (cons 'blank void)
                 (cons 'hand GDK_HAND2))))
 
-(define _GdkCursor (_cpointer 'GdkCursor))
+(define _GdkCursor (_cpointer/null 'GdkCursor))
 (define-gdk gdk_cursor_new  (_fun _int -> _GdkCursor))
 (define-gdk gdk_display_get_default (_fun -> _GdkDisplay))
 (define-gdk gdk_cursor_new_from_pixbuf (_fun _GdkDisplay _GdkPixbuf _int _int -> _GdkCursor))


### PR DESCRIPTION
Currently if I run on wayland if I try to run gui racket programs they just crash and I get the following error:

Gdk-Message: Unable to load arrow from the cursor theme [[this is from GTK, not Racket]]
GdkCursor->C: argument is not non-null `GdkCursor' pointer
  argument: #f

This small edit makes racket not crash (though I still get the Gdk-Message, I'm not sure what causes that), and gui Racket programs run just fine.  Allowing the cursor to be nullable doesn't seem to cause any problems from a brief look through cursor.rkt, but I'm no expert on racket/gui or on GTK.