### PR TITLE
Fix issue with dot-path's that contain a space

### DIFF
--- a/gui-lib/mrlib/private/dot.rkt
+++ b/gui-lib/mrlib/private/dot.rkt
@@ -107,7 +107,7 @@
      (λ ()
        (parameterize ([current-input-port in1]
                       [current-output-port out2])
-         (system (format "~a -Tplain" (path->string dot-path))))
+         (system (format "\"~a\" -Tplain" (path->string dot-path))))
        (close-output-port out2)
        (close-input-port in1)))
     (parse-plain in2)))


### PR DESCRIPTION
This PR fixes an issue with the `dot-positioning` function in `mrlib/graph` not working on systems that have the dot executable under a path containing spaces.

On Windows, the `dot-path` is usually something like `C:\Program Files\etc\etc`, and the space in the path name causes the call to fail with the error `'C:\Program' is not recognized as an internal or external command,
operable program or batch file.`. 

The issue is that the `dot-path` is being formatted as a string without quotes here: https://github.com/racket/gui/blob/master/gui-lib/mrlib/private/dot.rkt#L110

This may cause issues on other platforms as well, but I've only observed it on Windows. Not sure if there is a better solution but this worked for me :)