### PR TITLE
Fix for the documentation of get-token

### DIFF
--- a/gui-doc/scribblings/framework/color.scrbl
+++ b/gui-doc/scribblings/framework/color.scrbl
@@ -54,7 +54,7 @@
     @item{A symbol indicating how the token should be treated by the paren
       matcher or @racket[#f].  This symbol should be in the pairs argument.}
     @item{The starting position of the token (or @racket[#f] if eof); this
-          number is relative to the third result of @racket[get-port-location]
+          number is relative to the third result of @racket[port-next-location]
           when applied to the input port that gets passed to @racket[get-token].}
     @item{The ending position of the token (or @racket[#f] if eof); this 
           is also relative to the port's location, just like the previous value.}]

--- a/gui-doc/scribblings/framework/color.scrbl
+++ b/gui-doc/scribblings/framework/color.scrbl
@@ -64,7 +64,12 @@
     The offset given to @racket[get-token] can be added
     to the position of the input port to obtain absolute coordinates within a
     text stream. The extra two results are
-    @itemize[@item{a new mode; 
+    @itemize[@item{a backup distance;
+    The backup distance returned by @racket[get-token] indicates the
+    maximum number of characters to back up (counting from the start of the
+    token) and for re-parsing after a change to the editor within the token's
+    region.}
+    @item{a new mode; 
     The mode argument allows @racket[get-token] to communicate
     information from earlier parsing to later.  When @racket[get-token] is
     called for the beginning on a stream, the mode argument is @racket[#f];
@@ -84,12 +89,7 @@
     The mode should not be a mutable
     value; if part of the stream is re-tokenized, the mode saved from the
     immediately preceding token is given again to the @racket[get-token]
-    function.}
-    @item{a backup distance;
-    The backup distance returned by @racket[get-token] indicates the
-    maximum number of characters to back up (counting from the start of the
-    token) and for re-parsing after a change to the editor within the token's
-    region.}]
+    function.}]
 
     The @racket[get-token] function must obey the following invariants:
     @itemize[


### PR DESCRIPTION
Fixed the order of the two extra return values for get-token: the 'new mode' and 'backup distance' were swapped.