### PR TITLE
Fix bug where DrRacket could loose data when saving.

### DIFF
--- a/gui-lib/framework/private/text.rkt
+++ b/gui-lib/framework/private/text.rkt
@@ -2309,7 +2309,7 @@
              (or (not (preferences:get 'framework:verify-change-format))
                  (message-box/custom
                   (string-constant warning)
-                  (string-constant save-in-drs-format)
+                  (string-constant save-as-binary-format)
                   (string-constant yes)
                   (string-constant no)
                   (string-constant cancel)

--- a/gui-lib/framework/private/text.rkt
+++ b/gui-lib/framework/private/text.rkt
@@ -2310,9 +2310,9 @@
                  (message-box/custom
                   (string-constant warning)
                   (string-constant save-as-binary-format)
-                  (string-constant yes)
-                  (string-constant no)
-                  (string-constant cancel)
+                  (string-constant convert-format)
+                  (string-constant keep-format)
+                  (string-constant dont-save)
                   #f
                   '(disallow-close default=3)
                   3

--- a/gui-lib/framework/private/text.rkt
+++ b/gui-lib/framework/private/text.rkt
@@ -2304,19 +2304,27 @@
         (and (not (all-string-snips))
              (eq? format 'same)
              (eq? 'text (get-file-format))))
-      (define proper-format
-        (cond [(not needs-wxme?) #t]
-              [(and needs-wxme?
-                    (or (not (preferences:get 'framework:verify-change-format))
-                        (gui-utils:get-choice
-                         (string-constant save-in-drs-format)
-                         (string-constant yes)
-                         (string-constant no)
-                         #:dialog-mixin frame:focus-table-mixin)))
-               (set-file-format 'standard)
-               #t]
-              [else #f]))
-      (and proper-format (inner #t can-save-file? name format)))
+      (define format-converted
+        (and needs-wxme?
+             (or (not (preferences:get 'framework:verify-change-format))
+                 (message-box/custom
+                  (string-constant warning)
+                  (string-constant save-in-drs-format)
+                  (string-constant yes)
+                  (string-constant no)
+                  (string-constant cancel)
+                  #f
+                  '(disallow-close default=3)
+                  3
+                  #:dialog-mixin frame:focus-table-mixin))))
+      (define continue-saving?
+        (case format-converted
+          [(1 #t)
+           (set-file-format 'standard)
+           #t]
+          [(2) #t]
+          [(3) #f]))
+        (and continue-saving? (inner #t can-save-file? name format)))
     
     (define/augment (on-save-file name format)
       (when (and (all-string-snips)


### PR DESCRIPTION
At the moment if a user refuses to save a file with non-textual widgets
using wxme, DrRacket will just save the file as flattened text. This leads
to lost data, and makes otherwise valid racket files invalid.

This patch prevents the file from loosing that data on saving. Namely,
if a user:
1. Opened a file as a text file.
2. Added non-textual snips to the file.
3. Has in their preferences to warn before changing the file type.
4. Saves the file but refuses to change the type.

then DrRacket will not save the file because it cannot
do so.