### PR TITLE
Remove call to gdk_window_process_all_updates

### DIFF
--- a/gui-lib/mred/private/wx/gtk/window.rkt
+++ b/gui-lib/mred/private/wx/gtk/window.rkt
@@ -890,7 +890,6 @@
 (define-gdk gdk_display_get_default (_fun -> _GdkDisplay))
 (define (flush-display)
   (try-to-sync-refresh)
-  (gdk_window_process_all_updates)
   (gdk_display_flush (gdk_display_get_default)))
 
 (define-gdk gdk_window_freeze_updates (_fun _GdkWindow -> _void))


### PR DESCRIPTION
From https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#gdk-window-process-all-updates

> gdk_window_process_all_updates has been deprecated since version 3.22 and should not be used in newly-written code.

Calls to this function seem to add significant overhead when, for example, drawing text in a simple text editor. There seems to be no benefit to this call, as removing it still will have things be redrawn on flush-display via gdk_display_flush. I am not sure if there are legacy reasons for the call to gdk_window_process_all_updates, but it would be great to not have this call if it is not necessary.