### PR TITLE
make scribble double click select words, not lines

### DIFF
--- a/gui-lib/framework/private/racket.rkt
+++ b/gui-lib/framework/private/racket.rkt
@@ -1529,7 +1529,7 @@
              (define token (send text classify-position click-pos))
              (define-values (start end)
                (cond
-                 [(memq token '(string comment)) (word-based)]
+                 [(memq token '(string comment text)) (word-based)]
                  [(and (equal? token 'other)
                        (let-values ([(start end) (send text get-token-range click-pos)])
                          (and start


### PR DESCRIPTION
Currently, in at-exp languages, a double click on text selects the line not the word. This changes that.