### PR TITLE
factor expandable-snip etc out of syntax-browser snip

### DIFF
--- a/gui-doc/mrlib/scribblings/arrow-toggle-snip.scrbl
+++ b/gui-doc/mrlib/scribblings/arrow-toggle-snip.scrbl
@@ -1,0 +1,37 @@
+#lang scribble/doc
+@(require "common.rkt" (for-label mrlib/arrow-toggle-snip))
+
+@title{Arrow Toggle Snip}
+
+@defmodule[mrlib/arrow-toggle-snip]
+
+@defclass[arrow-toggle-snip% snip% ()]{
+
+Represents a toggle control, displayed as a right-facing arrow (off or
+``closed'') or a downward-facing arrow (on or ``open'').
+
+The size of the arrow is determined by the style (and font) applied to
+the snip. The arrow is drawn inscribed in a square resting on the
+baseline, but the snip reports its size (usually) as the same as a
+capital @litchar{X}; this means that the snip should look good next to
+text (in the same style) no matter whether base-aligned or
+top-aligned.
+
+@defconstructor[([callback (-> boolean? any) void])]{
+
+The @racket[on-up] and @racket[on-down] callbacks are called when the
+snip is toggled.
+}
+
+@defmethod[(get-toggle-state) boolean?]{
+
+Get the control's state.
+}
+
+@defmethod[(set-toggle-state [v boolean?]) void?]{
+
+Sets the control's state. If the new state is different from the
+previous state, the appropriate callback is called.
+}
+
+}

--- a/gui-doc/mrlib/scribblings/expandable-snip.scrbl
+++ b/gui-doc/mrlib/scribblings/expandable-snip.scrbl
@@ -1,0 +1,52 @@
+#lang scribble/doc
+@(require "common.rkt" (for-label mrlib/expandable-snip))
+
+@title{Expandable Snip}
+
+@defmodule[mrlib/expandable-snip]
+
+@defclass[expandable-snip% editor-snip% ()]{
+
+An expandable snip allows the user to toggle between two
+views---``open'' and ``closed''---implemented by two text
+editors. Typically the closed view is a concise summary and the open
+view contains more detailed information. The syntax browser snip is an
+example of an expandable snip.
+
+@defconstructor/auto-super[([layout (or/c 'append 'replace) 'append]
+                            [closed-editor (is-a?/c text%) (new text%)]
+                            [open-editor (is-a?/c text%) (new text%)]
+                            [open/close-callback
+                             (-> (is-a?/c expandable-snip%) boolean? any)
+                             void])]{
+
+The @racket[open/close-callback] is called when the snip state is
+toggled. It is called with the expandable snip object and a boolean
+that indicates whether the new state is open.
+
+In closed mode, the toggle arrow and @racket[closed-editor] are
+displayed adjacent on a single line. In open mode, the layout is
+controlled by the @racket[layout] argument as follows:
+@itemlist[
+
+@item{@racket['append] --- The first line is unchanged (that is, it
+contains both toggle arrow and @racket[closed-editor]), and
+@racket[open-editor] is displayed on the second line.}
+
+@item{@racket['replace] --- The toggle arrow and the
+@racket[open-editor] are displayed on a single line. The
+@racket[closed-editor] is not displayed.}
+
+]
+}
+
+@defmethod[(get-open-editor) (is-a?/c text%)]{
+
+Get the editor for the open mode.
+}
+
+@defmethod[(get-closed-editor) (is-a?/c text%)]{
+
+Gets the editor for the closed mode.
+}
+}

--- a/gui-doc/mrlib/scribblings/mrlib.scrbl
+++ b/gui-doc/mrlib/scribblings/mrlib.scrbl
@@ -6,9 +6,11 @@
 @table-of-contents[]
 
 @include-section["aligned-pasteboard/aligned-pasteboard.scrbl"]
+@include-section["arrow-toggle-snip.scrbl"]
 @include-section["bitmap-label.scrbl"]
 @include-section["cache-image-snip.scrbl"]
 @include-section["close-icon.scrbl"]
+@include-section["expandable-snip.scrbl"]
 @include-section["gif.scrbl"]
 @include-section["graph/graph.scrbl"]
 @include-section["hierlist/hierlist.scrbl"]

--- a/gui-lib/mrlib/arrow-toggle-snip.rkt
+++ b/gui-lib/mrlib/arrow-toggle-snip.rkt
@@ -1,15 +1,73 @@
 #lang racket/base
 (require racket/class
-         racket/gui/base
-         mrlib/include-bitmap)
+         racket/gui/base)
 (provide arrow-toggle-snip%)
+
+;; arrow-toggle-snip% represents a togglable state, displayed as a right-facing
+;; arrow (off or "closed") or a downward-facing arrow (on or "open").
+
+;; The size of the arrow is determined by the style (and font) applied to the
+;; snip. The arrow is drawn inscribed in a square resting on the baseline, but
+;; the snip reports its size (usually) as the same as a capital "X"; this means
+;; that the snip should look good next to text (in the same style) no matter
+;; whether base-aligned or top-aligned.
+
+;; ------------------------------------------------------------
+;; Paths and gradients, in terms of 100x100 box
+
+(define (down-arrow-path scale yb)
+  (define (tx x) (* scale x))
+  (define (ty y) (+ yb (* scale y)))
+  (define p (new dc-path%))
+  (send* p
+    [move-to (tx 10) (ty 40)]
+    [line-to (tx 90) (ty 40)]
+    [line-to (tx 50) (ty 75)]
+    [line-to (tx 10) (ty 40)]
+    [close])
+  p)
+
+(define (down-arrow-gradient scale xb yb)
+  (define (tx x) (+ xb (* scale x)))
+  (define (ty y) (+ yb (* scale y)))
+  (new linear-gradient%
+       [x0 (tx 50)] [y0 (ty 40)]
+       [x1 (tx 50)] [y1 (ty 75)]
+       [stops
+        (list (list 0 (make-object color% 240 240 255))
+              (list 1 (make-object color% 128 128 255)))]))
+
+(define (right-arrow-path scale yb)
+  (define (tx x) (* scale x))
+  (define (ty y) (+ yb (* scale y)))
+  (define p (new dc-path%))
+  (send* p
+    [move-to (tx 40) (ty 10)]
+    [line-to (tx 75) (ty 50)]
+    [line-to (tx 40) (ty 90)]
+    [line-to (tx 40) (ty 10)]
+    [close])
+  p)
+
+(define (right-arrow-gradient scale xb yb)
+  (define (tx x) (+ xb (* scale x)))
+  (define (ty y) (+ yb (* scale y)))
+  (new linear-gradient%
+       [x0 (tx 40)] [y0 (ty 50)]
+       [x1 (tx 75)] [y1 (ty 50)]
+       [stops
+        (list (list 0 (make-object color% 240 240 255))
+              (list 1 (make-object color% 128 128 255)))]))
+
+;; ------------------------------------------------------------
 
 (define arrow-toggle-snip%
   (class snip%
-    (inherit get-admin get-flags set-flags set-count)
-    (init-field [open? #f]
-                [on-up void]
-                [on-down void])
+    (inherit get-admin get-flags get-style set-flags set-count)
+    (init [open? #f])
+    (init-field [on-up void]
+                [on-down void]
+                [size #f])
     (field [state (if open? 'down 'up)])  ; (U 'up 'down 'up-click 'down-click)
     (super-new)
     (set-count 1)
@@ -19,62 +77,81 @@
       (new arrow-toggle-snip% (on-up on-up) (on-down on-down) (state state)))
 
     (define/override (draw dc x y left top right bottom dx dy draw-caret)
-      (define bitmap
+      (define old-brush (send dc get-brush))
+      (define old-pen (send dc get-pen))
+      (define old-smoothing (send dc get-smoothing))
+      (define-values (size dy*) (get-target-size* dc))
+      (define scale-factor (/ size 100))
+      (define arrow-path
         (case state
-          [(up) up-bitmap]
-          [(down) down-bitmap]
-          [(up-click) up-click-bitmap]
-          [(down-click) down-click-bitmap]))
-      (cond [(send bitmap ok?)
-             (send dc draw-bitmap bitmap x y)]
-            [(send dc draw-rectangle x y 10 10)
-             (send dc drawline x y 10 10)]))
+          [(up up-click) (right-arrow-path scale-factor dy*)]
+          [(down down-click) (down-arrow-path scale-factor dy*)]))
+      (define arrow-gradient
+        (case state
+          [(up up-click) (right-arrow-gradient scale-factor x (+ dy* y))]
+          [(down down-click) (down-arrow-gradient scale-factor x (+ dy* y))]))
+      ;; Draw arrow
+      (send* dc
+        [set-pen "black" 0 'solid]
+        [set-brush (new brush% [gradient arrow-gradient])]
+        [set-smoothing 'aligned]
+        [draw-path arrow-path x y])
+      ;; Restore
+      (send* dc
+        [set-brush old-brush]
+        [set-pen old-pen]))
 
     (define/override (get-extent dc x y w h descent space lspace rspace)
+      (define-values (size dy) (get-target-size* dc))
       (set-box/f! descent 0)
       (set-box/f! space 0)
       (set-box/f! lspace 0)
       (set-box/f! rspace 0)
-      (set-box/f! w arrow-snip-width)
-      (set-box/f! h arrow-snip-height))
+      (set-box/f! w size)
+      (set-box/f! h (+ size dy)))
+
+    ;; get-target-size* : -> (values Real Real)
+    ;; Returns size of drawn square and dy to drop to baseline so whole
+    ;; snip takes up same space as "X". (This is a hack because baseline
+    ;; alignment would cause problems elsewhere.)
+    (define/private (get-target-size* dc)
+      (define-values (xw xh xd xa)
+        (send dc get-text-extent "X" (send (get-style) get-font)))
+      (let ([size (or size (* xh 0.6))])
+        (values size (max 0 (- xh xd size)))))
 
     (define/override (on-event dc x y editorx editory evt)
+      (define-values (arrow-snip-width dh) (get-target-size* dc))
+      (define arrow-snip-height (+ arrow-snip-width dh))
       (let ([snip-evt-x (- (send evt get-x) x)]
             [snip-evt-y (- (send evt get-y) y)])
         (cond
-         [(send evt button-down? 'left)
-          (set-state (case state
-                       [(up) 'up-click]
-                       [(down) 'down-click]
-                       [else 'down-click]))]
-         [(and (send evt button-up? 'left)
-               (<= 0 snip-evt-x arrow-snip-width)
-               (<= 0 snip-evt-y arrow-snip-height))
-          (case state
-            [(up up-click) (set-state 'down) (on-down)]
-            [(down down-click) (set-state 'up) (on-up)]
-            [else (set-state 'down)])]
-         [(send evt button-up? 'left)
-          (set-state (case state
-                       [(up up-click) 'up]
-                       [(down down-click) 'down]
-                       [else 'up]))]
-         [(and (send evt get-left-down)
-               (send evt dragging?)
-               (<= 0 snip-evt-x arrow-snip-width)
-               (<= 0 snip-evt-y arrow-snip-height))
-          (set-state (case state
-                       [(up up-click) 'up-click]
-                       [(down down-click) 'down-click]
-                       [else 'up-click]))]
-         [(and (send evt get-left-down)
-               (send evt dragging?))
-          (set-state (case state
-                       [(up up-click) 'up]
-                       [(down down-click) 'down]
-                       [else 'up-click]))]
-         [else
-          (super on-event dc x y editorx editory evt)])))
+          [(send evt button-down? 'left)
+           (set-state (case state
+                        [(up) 'up-click]
+                        [else 'down-click]))]
+          [(send evt button-up? 'left)
+           (cond [(and (<= 0 snip-evt-x arrow-snip-width)
+                       (<= 0 snip-evt-y arrow-snip-height))
+                  (set-state (case state
+                               [(down down-click) 'up]
+                               [else 'down]))]
+                 [else
+                  (set-state (case state
+                               [(down down-click) 'down]
+                               [else 'up]))])]
+          [(and (send evt get-left-down)
+                (send evt dragging?))
+           (cond [(and (<= 0 snip-evt-x arrow-snip-width)
+                       (<= 0 snip-evt-y arrow-snip-height))
+                  (set-state (case state
+                               [(down down-click) 'down-click]
+                               [else 'up-click]))]
+                 [else
+                  (set-state (case state
+                               [(down down-click) 'down]
+                               [else 'up]))])]))
+      (super on-event dc x y editorx editory evt))
 
     (define/public (get-open)
       (case state [(down down-click) #t] [else #f]))
@@ -84,32 +161,20 @@
 
     (define/private (set-state new-state)
       (unless (eq? state new-state)
+        (define old-toggled? (get-open))
         (set! state new-state)
         (let ([admin (get-admin)])
           (when admin
-            (send admin needs-update this 0 0 arrow-snip-width arrow-snip-height)))))
+            (define-values (size dy) (get-target-size* (send admin get-dc)))
+            (send admin needs-update this 0 0 size (+ size dy))))
+        (define new-toggled? (get-open))
+        (unless (equal? new-toggled? old-toggled?)
+          (if new-toggled? (on-down) (on-up)))))
 
     (define/override (adjust-cursor dc x y editorx editory event)
       arrow-snip-cursor)
     ))
 
 (define (set-box/f! b v) (when (box? b) (set-box! b v)))
-(define down-bitmap (include-bitmap (lib "icons/turn-down.png") 'png))
-(define up-bitmap (include-bitmap (lib "icons/turn-up.png") 'png))
-(define down-click-bitmap (include-bitmap (lib "icons/turn-down-click.png") 'png))
-(define up-click-bitmap (include-bitmap (lib "icons/turn-up-click.png") 'png))
-
-(define arrow-snip-height
-  (max 10
-       (send up-bitmap get-height)
-       (send down-bitmap get-height)
-       (send up-click-bitmap get-height)
-       (send down-click-bitmap get-height)))
-(define arrow-snip-width
-  (max 10
-       (send up-bitmap get-width)
-       (send down-bitmap get-width)
-       (send up-click-bitmap get-width)
-       (send down-click-bitmap get-width)))
 
 (define arrow-snip-cursor (make-object cursor% 'arrow))

--- a/gui-lib/mrlib/arrow-toggle-snip.rkt
+++ b/gui-lib/mrlib/arrow-toggle-snip.rkt
@@ -1,0 +1,115 @@
+#lang racket/base
+(require racket/class
+         racket/gui/base
+         mrlib/include-bitmap)
+(provide arrow-toggle-snip%)
+
+(define arrow-toggle-snip%
+  (class snip%
+    (inherit get-admin get-flags set-flags set-count)
+    (init-field [open? #f]
+                [on-up void]
+                [on-down void])
+    (field [state (if open? 'down 'up)])  ; (U 'up 'down 'up-click 'down-click)
+    (super-new)
+    (set-count 1)
+    (set-flags (cons 'handles-events (get-flags)))
+
+    (define/override (copy)
+      (new arrow-toggle-snip% (on-up on-up) (on-down on-down) (state state)))
+
+    (define/override (draw dc x y left top right bottom dx dy draw-caret)
+      (define bitmap
+        (case state
+          [(up) up-bitmap]
+          [(down) down-bitmap]
+          [(up-click) up-click-bitmap]
+          [(down-click) down-click-bitmap]))
+      (cond [(send bitmap ok?)
+             (send dc draw-bitmap bitmap x y)]
+            [(send dc draw-rectangle x y 10 10)
+             (send dc drawline x y 10 10)]))
+
+    (define/override (get-extent dc x y w h descent space lspace rspace)
+      (set-box/f! descent 0)
+      (set-box/f! space 0)
+      (set-box/f! lspace 0)
+      (set-box/f! rspace 0)
+      (set-box/f! w arrow-snip-width)
+      (set-box/f! h arrow-snip-height))
+
+    (define/override (on-event dc x y editorx editory evt)
+      (let ([snip-evt-x (- (send evt get-x) x)]
+            [snip-evt-y (- (send evt get-y) y)])
+        (cond
+         [(send evt button-down? 'left)
+          (set-state (case state
+                       [(up) 'up-click]
+                       [(down) 'down-click]
+                       [else 'down-click]))]
+         [(and (send evt button-up? 'left)
+               (<= 0 snip-evt-x arrow-snip-width)
+               (<= 0 snip-evt-y arrow-snip-height))
+          (case state
+            [(up up-click) (set-state 'down) (on-down)]
+            [(down down-click) (set-state 'up) (on-up)]
+            [else (set-state 'down)])]
+         [(send evt button-up? 'left)
+          (set-state (case state
+                       [(up up-click) 'up]
+                       [(down down-click) 'down]
+                       [else 'up]))]
+         [(and (send evt get-left-down)
+               (send evt dragging?)
+               (<= 0 snip-evt-x arrow-snip-width)
+               (<= 0 snip-evt-y arrow-snip-height))
+          (set-state (case state
+                       [(up up-click) 'up-click]
+                       [(down down-click) 'down-click]
+                       [else 'up-click]))]
+         [(and (send evt get-left-down)
+               (send evt dragging?))
+          (set-state (case state
+                       [(up up-click) 'up]
+                       [(down down-click) 'down]
+                       [else 'up-click]))]
+         [else
+          (super on-event dc x y editorx editory evt)])))
+
+    (define/public (get-open)
+      (case state [(down down-click) #t] [else #f]))
+
+    (define/public (set-open new-state)
+      (set-state (if new-state 'down 'up)))
+
+    (define/private (set-state new-state)
+      (unless (eq? state new-state)
+        (set! state new-state)
+        (let ([admin (get-admin)])
+          (when admin
+            (send admin needs-update this 0 0 arrow-snip-width arrow-snip-height)))))
+
+    (define/override (adjust-cursor dc x y editorx editory event)
+      arrow-snip-cursor)
+    ))
+
+(define (set-box/f! b v) (when (box? b) (set-box! b v)))
+(define down-bitmap (include-bitmap (lib "icons/turn-down.png") 'png))
+(define up-bitmap (include-bitmap (lib "icons/turn-up.png") 'png))
+(define down-click-bitmap (include-bitmap (lib "icons/turn-down-click.png") 'png))
+(define up-click-bitmap (include-bitmap (lib "icons/turn-up-click.png") 'png))
+
+(define arrow-snip-height
+  (max 10
+       (send up-bitmap get-height)
+       (send down-bitmap get-height)
+       (send up-click-bitmap get-height)
+       (send down-click-bitmap get-height)))
+(define arrow-snip-width
+  (max 10
+       (send up-bitmap get-width)
+       (send down-bitmap get-width)
+       (send up-click-bitmap get-width)
+       (send down-click-bitmap get-width)))
+
+(define arrow-snip-cursor (make-object cursor% 'arrow))

--- a/gui-lib/mrlib/expandable-snip.rkt
+++ b/gui-lib/mrlib/expandable-snip.rkt
@@ -1,0 +1,158 @@
+#lang racket/base
+(require racket/class
+         racket/gui/base
+         "arrow-toggle-snip.rkt")
+(provide inherit-styles-editor-snip%
+         expandable-snip%)
+
+;; inherit-styles-editor-snip% propagates the style list of its enclosing
+;; editor to its own editor.
+
+(define inherit-styles-editor-snip%
+  (class editor-snip%
+    (inherit get-admin get-editor)
+    (init-field [inherit-styles? #t])
+    (super-new)
+    (define/override (set-admin a)
+      (super set-admin a)
+      (define new-admin (get-admin))
+      (when (and inherit-styles? new-admin)
+        (define sl (send (send new-admin get-editor) get-style-list))
+        (update-style-list sl)))
+    ;; hook for additional action on style-list change:
+    (define/public (update-style-list sl)
+      (send (get-editor) set-style-list sl))))
+
+;; ============================================================
+
+;; An expandable snip consists of three parts: an arrow toggle snip,
+;; the summary text, and the expanded text. The arrow toggles between
+;; closed and open mode. In closed mode, only the toggle snip and
+;; summary text are displayed adjacent on a single line. There are two
+;; layout options for open mode:
+;; - 'append:  The first line is unchanged, and the expanded text is
+;;             displayed on the second line.
+;; - 'replace: The summary text is replaced with the expanded text.
+
+;; expandable-snip%
+(define expandable-snip%
+  (class inherit-styles-editor-snip%
+    (inherit get-editor
+             get-admin)
+    (init [closed-editor (new text%)]
+          [open-editor (new text%)]
+          [callback void])
+    (init-field [layout 'append]) ;; (U 'replace 'append)
+    (super-new)
+
+    (field [open? #f])
+
+    (field [open-es (new editor-snip% (editor open-editor) (with-border? #f))])
+    (send open-es set-margin 0 0 0 0)
+    (send open-es set-inset 0 0 0 0)
+
+    (field [closed-es (new editor-snip% (editor closed-editor) (with-border? #f))])
+    (send closed-es set-margin 0 0 0 0)
+    (send closed-es set-inset 0 0 0 0)
+
+    (let ([outer-t (get-editor)])
+      (define (toggle-callback now-open?)
+        (unless (eq? now-open? open?)
+          (set! open? now-open?)
+          (refresh-contents)
+          (callback now-open?)))
+      (send* outer-t
+        [insert (new arrow-toggle-snip% [callback toggle-callback])]
+        [change-style top-aligned 0 (send outer-t last-position)]
+        ;; Can't base-align; messes up with 'replace layout
+        ;; [change-style base-aligned 0 1]
+        [hide-caret #t]
+        [lock #t]))
+
+    (define/public (get-open-editor) (send open-es get-editor))
+    (define/public (get-closed-editor) (send closed-es get-editor))
+
+    (define/public (get-open-state) open?)
+    (define/public (set-open-state v)
+      (let ([v (and v #t)])
+        (unless (eq? open? v)
+          (set! open? v)
+          (refresh-contents))))
+
+    (define/override (update-style-list sl)
+      (super update-style-list sl)
+      (define outer-t (get-editor))
+      (define standard (send sl find-named-style "Standard"))
+      (with-unlock outer-t
+        (send outer-t change-style standard 0 (send outer-t last-position))))
+
+    ;; if layout is 'replace, editor contains
+    ;;  - open? = #f : [turn-snip][closed-es]
+    ;;  - open? = #t : [turn-snip][open-es]
+    ;; if layout is 'append, editor contains
+    ;;  - open? = #f : [turn-snip][closed-es]
+    ;;  - open? = #t : [turn-snip][closed-es]\n[open-es]
+
+    (define/private (refresh-contents)
+      (define outer-t (get-editor))
+      (with-unlock outer-t
+        (send outer-t release-snip closed-es)
+        (send outer-t release-snip open-es)
+        (send outer-t delete 1 (send outer-t last-position))
+        (when (or (not open?) (eq? layout 'append))
+          (send outer-t insert closed-es (send outer-t last-position)))
+        (when (and open? (eq? layout 'append))
+          (send outer-t insert "\n" (send outer-t last-position)))
+        (when open?
+          (send outer-t insert open-es (send outer-t last-position)))
+        (send outer-t change-style top-aligned 0 (send outer-t last-position))))
+
+    (refresh-contents)
+    ))
+
+(define top-aligned (make-object style-delta% 'change-alignment 'top))
+(define base-aligned (make-object style-delta% 'change-alignment 'base))
+
+;; (with-unlock text-expression . body)
+(define-syntax with-unlock
+  (syntax-rules ()
+    [(with-unlock text . body)
+     (let* ([t text] [locked? (send t is-locked?)])
+       (dynamic-wind
+         (lambda ()
+           (send* t
+             (begin-edit-sequence #f)
+             (lock #f)))
+         (lambda () . body)
+         (lambda ()
+           (send* t
+             (lock locked?)
+             (end-edit-sequence)))))]))
+
+;; ============================================================
+
+(module+ main
+  (provide (all-defined-out))
+  (define f (new frame% (label "test") (height 400) (width 600)))
+  (define t (new text%))
+  (define ec (new editor-canvas% (editor t) (parent f)))
+  (send f show #t)
+
+  (send t insert "Here's what's I'm talking about,\na nice expandable snip: ")
+
+  (define es (new expandable-snip% (with-border? #t) (layout 'append)))
+  ;;(send es set-margin 0 0 0 0)
+
+  (send* (send es get-closed-editor)
+    [insert "alphabet"]
+    ;; [hide-caret #t]
+    [lock #t])
+
+  (send* (send es get-open-editor)
+    [insert "abcdefg\nhijklmno\npqrstuv\nwxyz"]
+    ;; [hide-caret #t]
+    [lock #t])
+
+  (send t insert es)
+  (send t hide-caret #t)
+  (send t lock #t))

--- a/gui-lib/mrlib/hierlist.rkt
+++ b/gui-lib/mrlib/hierlist.rkt
@@ -1,7 +1,7 @@
-#lang scheme/base
+#lang racket/base
 
 (require mzlib/unit
-         scheme/gui/base
+         racket/gui/base
          "hierlist/hierlist-sig.rkt"
          "hierlist/hierlist-unit.rkt")
 
@@ -9,29 +9,27 @@
 
 (provide-signature-elements hierlist^)
 
-#|
+;; ============================================================
 
-;; Testing
-(define f (make-object frame% "test"))
+(module+ demo
+(require racket/class)
+
+(define f (make-object frame% (format "test ~s" (version))))
 (define p (make-object horizontal-panel% f))
-(define c (make-object (class hierarchical-list% args
-			 (override
-			   [on-item-opened
-			    (lambda (i)
-			      (let ([f (send i user-data)])
-				(when f (f i))))]
-			   [on-select
-			    (lambda (i)
-			      (printf "Selected: ~a\n"
-				      (if i 
-					  (send (send i get-editor) get-flattened-text)
-					  i)))]
-			   [on-double-select
-			    (lambda (s)
-			      (printf "Double-click: ~a\n"
-				      (send (send s get-editor) get-flattened-text)))])
-			 (sequence (apply super-init args)))
-		       p))
+(define c (make-object (class hierarchical-list%
+                         (define/override (on-item-opened i)
+                           (let ([f (send i user-data)])
+                             (when f (f i))))
+                         (define/override (on-select i)
+                           (printf "Selected: ~a\n"
+                                   (if i 
+                                       (send (send i get-editor) get-flattened-text)
+                                       i)))
+                         (define/override (on-double-select s)
+                           (printf "Double-click: ~a\n"
+                                   (send (send s get-editor) get-flattened-text)))
+                         (super-new))
+                       p))
 
 (define a (send c new-list))
 (send (send a get-editor) insert "First Item: List")
@@ -58,8 +56,12 @@
 (define y (send c new-item))
 (send (send y get-editor) insert "y")
 
+(define z (send c new-list))
+(send (send z get-editor) insert "a multi-line\nlabel")
+(send (send (send z new-item) get-editor) insert "Sub1")
+(send (send (send z new-item) get-editor) insert "Sub2")
+
 (send f show #t)
 
 (yield (make-semaphore))
-
-|#
+)

--- a/gui-lib/mrlib/hierlist/hierlist-unit.rkt
+++ b/gui-lib/mrlib/hierlist/hierlist-unit.rkt
@@ -46,16 +46,15 @@
       (send arrow-snip-class set-classname "hier-arrow")
       (define arrow-snip%
         (class arrow-toggle-snip%
-          (inherit get-open set-open set-snipclass set-count)
+          (inherit get-toggle-state set-toggle-state set-snipclass set-count)
           (init callback)
-          (super-new [on-up (lambda () (callback this))]
-                     [on-down (lambda () (callback this))]
+          (super-new [callback (lambda (new-state) (callback this))]
                      [size 14]) ;; 14 is close to previous size
           (set-snipclass arrow-snip-class)
           (define/public on
             (case-lambda
-              [() (get-open)]
-              [(v) (set-open v)]))))
+              [() (get-toggle-state)]
+              [(v) (set-toggle-state v)]))))
 
       ;; Hack to get whitespace matching width of arrow: derive a new
       ;; class that overrides the `draw' method to do nothing. 

--- a/gui-lib/mrlib/hierlist/hierlist-unit.rkt
+++ b/gui-lib/mrlib/hierlist/hierlist-unit.rkt
@@ -49,7 +49,8 @@
           (inherit get-open set-open set-snipclass set-count)
           (init callback)
           (super-new [on-up (lambda () (callback this))]
-                     [on-down (lambda () (callback this))])
+                     [on-down (lambda () (callback this))]
+                     [size 14]) ;; 14 is close to previous size
           (set-snipclass arrow-snip-class)
           (define/public on
             (case-lambda

--- a/gui-lib/mrlib/syntax-browser.rkt
+++ b/gui-lib/mrlib/syntax-browser.rkt
@@ -15,7 +15,8 @@ needed to really make this work:
            racket/match
            racket/contract
            (prefix-in : racket/base)
-           "include-bitmap.rkt")
+           "include-bitmap.rkt"
+           "arrow-toggle-snip.rkt")
 
   (define orig-output-port (current-output-port))
   (define (oprintf . args) (apply fprintf orig-output-port args))
@@ -336,7 +337,7 @@ needed to really make this work:
       
       (let ()
         
-        (send outer-t insert (new turn-snip% 
+        (send outer-t insert (new arrow-toggle-snip% 
                                   [on-up (λ () (hide-details))]
                                   [on-down (λ () (show-details))]))
         (send outer-t insert (format "~s\n" main-stx))
@@ -488,118 +489,6 @@ needed to really make this work:
   (void (send green-style-delta set-delta-foreground "forest green"))
   (define small-style (make-object style-delta% 'change-size 4))
   
-  (define turn-snip%
-    (class snip%
-      
-      (init-field on-up on-down)
-      
-      ;; state : (union 'up 'down 'up-click 'down-click))
-      (init-field [state 'up])
-      
-      (define/override (copy)
-        (instantiate turn-snip% ()
-          (on-up on-up)
-          (on-down on-down)
-          (state state)))
-      
-      (define/override (draw dc x y left top right bottom dx dy draw-caret)
-        (let ([bitmap (case state
-                        [(up) up-bitmap]
-                        [(down) down-bitmap]
-                        [(up-click) up-click-bitmap]
-                        [(down-click) down-click-bitmap])])
-          (cond
-            [(send bitmap ok?)
-             (send dc draw-bitmap bitmap x y)]
-            [(send dc draw-rectangle x y 10 10)
-             (send dc drawline x y 10 10)])))
-             
-
-      (define/override (get-extent dc x y w h descent space lspace rspace)
-        (set-box/f! descent 0)
-        (set-box/f! space 0)
-        (set-box/f! lspace 0)
-        (set-box/f! rspace 0)
-        (set-box/f! w arrow-snip-width)
-        (set-box/f! h arrow-snip-height))
-      
-      (define/override (on-event dc x y editorx editory evt)
-        (let ([snip-evt-x (- (send evt get-x) x)]
-              [snip-evt-y (- (send evt get-y) y)])
-          (cond
-            [(send evt button-down? 'left)
-             (set-state (case state
-                          [(up) 'up-click]
-                          [(down) 'down-click]
-                          [else 'down-click]))]
-            [(and (send evt button-up? 'left)
-                  (<= 0 snip-evt-x arrow-snip-width)
-                  (<= 0 snip-evt-y arrow-snip-height))
-             (set-state (case state
-                          [(up up-click) 
-                           (on-down)
-                           'down]
-                          [(down down-click)
-                           (on-up)
-                           'up]
-                          [else 'down]))]
-            [(send evt button-up? 'left)
-             (set-state (case state
-                          [(up up-click) 'up]
-                          [(down down-click) 'down]
-                          [else 'up]))]
-            [(and (send evt get-left-down)
-                  (send evt dragging?)
-                  (<= 0 snip-evt-x arrow-snip-width)
-                  (<= 0 snip-evt-y arrow-snip-height))
-             (set-state (case state
-                          [(up up-click) 'up-click]
-                          [(down down-click) 'down-click]
-                          [else 'up-click]))]
-            [(and (send evt get-left-down)
-                  (send evt dragging?))
-             (set-state (case state
-                          [(up up-click) 'up]
-                          [(down down-click) 'down]
-                          [else 'up-click]))]
-            [else
-             (super on-event dc x y editorx editory evt)])))
-
-      (inherit get-admin)
-      (define/private (set-state new-state)
-        (unless (eq? state new-state)
-          (set! state new-state)
-          (let ([admin (get-admin)])
-            (when admin
-              (send admin needs-update this 0 0 arrow-snip-width arrow-snip-height)))))
-      
-      (define/override (adjust-cursor dc x y editorx editory event) arrow-snip-cursor)
-      
-      (super-instantiate ())
-      
-      (inherit get-flags set-flags)
-      (set-flags (cons 'handles-events (get-flags)))))
-  
-  (define (set-box/f! b v) (when (box? b) (set-box! b v)))
-  
-  (define down-bitmap (include-bitmap (lib "icons/turn-down.png") 'png))
-  (define up-bitmap (include-bitmap (lib "icons/turn-up.png") 'png))
-  (define down-click-bitmap (include-bitmap (lib "icons/turn-down-click.png") 'png))
-  (define up-click-bitmap (include-bitmap (lib "icons/turn-up-click.png") 'png))
-  (define arrow-snip-height
-    (max 10
-         (send up-bitmap get-height)
-         (send down-bitmap get-height)
-         (send up-click-bitmap get-height)
-         (send down-click-bitmap get-height)))
-  (define arrow-snip-width
-    (max 10
-         (send up-bitmap get-width)
-         (send down-bitmap get-width)
-         (send up-click-bitmap get-width)
-         (send down-click-bitmap get-width)))
-  (define arrow-snip-cursor (make-object cursor% 'arrow))
-
   ;; make-text-port : text -> port
   ;; builds a port from a text object.  
   (define (make-text-port text)

--- a/gui-lib/mrlib/syntax-browser.rkt
+++ b/gui-lib/mrlib/syntax-browser.rkt
@@ -232,8 +232,7 @@ needed to really make this work:
                 (send info-text last-position))))
       
       (define/private (insert/big str)
-        (let ([sd (make-object style-delta% 'change-bold)])
-          (send sd set-delta-foreground "Navy")
+        (let ([sd (make-big-style-delta)])
           (let ([pos (send info-text last-position)])
             (send info-text insert str 
                   (send info-text last-position)
@@ -242,6 +241,11 @@ needed to really make this work:
                   sd
                   pos 
                   (send info-text last-position)))))
+
+      (define/private (make-big-style-delta)
+        (define sd (make-object style-delta% 'change-bold))
+        (send sd set-delta-foreground "Navy")
+        sd)
       
       (define/private (optional-newline)
         (unless (equal?

--- a/gui-lib/mrlib/syntax-browser.rkt
+++ b/gui-lib/mrlib/syntax-browser.rkt
@@ -136,7 +136,7 @@ needed to really make this work:
                          [pretty-print-pre-print-hook range-pretty-print-pre-hook]
                          [pretty-print-post-print-hook range-pretty-print-post-hook]
                          [pretty-print-columns 30])
-            (pretty-print datum)
+            (pretty-write datum)
             (make-modern output-text)))
 
         (values range-start-ht range-ht))


### PR DESCRIPTION
Adds two new snip classes:
- `arrow-toggle-snip%` is a toggle control. Uses include syntax snips and hierlist lists. This PR changes the snip to scale with the style's font size.
- `expandable-snip%` extracts the toggle-for-details part of syntax snips.
