### PR TITLE
Add splicing-parameterize to default indentation

### DIFF
--- a/gui-lib/framework/private/main.rkt
+++ b/gui-lib/framework/private/main.rkt
@@ -437,7 +437,7 @@
                splicing-letrec-values splicing-let-syntax
                splicing-letrec-syntax splicing-let-syntaxes
                splicing-letrec-syntaxes splicing-letrec-syntaxes+values
-               splicing-local splicing-syntax-parameterize
+               splicing-local splicing-parameterize splicing-syntax-parameterize
 
                do:
                


### PR DESCRIPTION
This is because splicing-parameterize is now part of the
racket/splicing library.