### PR TITLE
gui-lib: add dependency on icons

### DIFF
--- a/gui-lib/info.rkt
+++ b/gui-lib/info.rkt
@@ -4,6 +4,7 @@
 
 (define deps '("srfi-lite-lib"
                "data-lib"
+               "icons"
                ["base" #:version "7.0.0.9"]
                "syntax-color-lib"
                ["draw-lib" #:version "1.13"]


### PR DESCRIPTION
Several places make references to (lib "myfilename.png" "icons"),
where that file is not in gui-lib/icons, but in the icons package.