### PR TITLE
use correct character for longrightarrow

### DIFF
--- a/tex-table/tex-table.rkt
+++ b/tex-table/tex-table.rkt
@@ -26,7 +26,7 @@
     ("leftarrow" "←")
     ("uparrow" "↑")
     ("Leftarrow" "⇐")
-    ("longrightarrow" "−")
+    ("longrightarrow" "⟶")
     ("Uparrow" "⇑")
     ("Leftrightarrow" "⇔")
     ("updownarrow" "↕")


### PR DESCRIPTION
The old one was Minus Sign. 