### PR TITLE
fix scroll position of popup menus when on the bottom of monitor

### DIFF
--- a/gui-lib/mred/private/wx/gtk/menu.rkt
+++ b/gui-lib/mred/private/wx/gtk/menu.rkt
@@ -145,8 +145,7 @@
                           (ptr-set! _y _int (min (->screen y)
                                                  (max 0
                                                       (- sh
-                                                         (GtkRequisition-height r)))))))
-                      (ptr-set! _push _gboolean #t))
+                                                         (GtkRequisition-height r))))))))
                     #f
                     0
 		    recent-event-time))


### PR DESCRIPTION
Originally I found the issue reported here : https://github.com/MatrixForChange/files-viewer/issues/28 , but then I found it is a common issue of the gtk backend of racket/gui. Screenshots is available in that issue.

If I understand correctly (according to https://developer.gnome.org/gtk3/stable/GtkMenu.html#GtkMenuPositionFunc), only combobox-like things would need to set the push_in to true, and removing that line seems to be a solution.

Feel free to close this if I actually missed something.