### PR TITLE
fix mismatched word-end-pos for autocomplete

### DIFF
--- a/gui-lib/framework/private/text.rkt
+++ b/gui-lib/framework/private/text.rkt
@@ -3990,6 +3990,7 @@ designates the character that triggers autocompletion
         (let ([reasonable? (send completions-box widen)])
           (cond
             [reasonable?
+             (set! word-end-pos (sub1 word-end-pos))
              (let-values ([(_ __ x1p y1p) (send completions-box get-menu-coordinates)])
                (invalidate-bitmap-cache x0 y0 (max x1 x1p) (max y1 y1p)))]
             [else

--- a/gui-test/framework/tests/text.rkt
+++ b/gui-test/framework/tests/text.rkt
@@ -18,7 +18,8 @@
     (text:ports-tests)
     (move/copy-to-edit-tests)
     (move/copy-to-edit-random-tests)
-    (ascii-art-tests)))
+    (ascii-art-tests)
+    (autocomplete-tests)))
 
 (define (highlight-range-tests)
   (check-equal?
@@ -967,3 +968,21 @@
                  "╠══╬═╣\n"
                  "║  ║ ║\n"
                  "╚══╩═╝\n")))
+
+(define (autocomplete-tests)
+  (define t (new (class (text:autocomplete-mixin text%)
+                   (define/override (get-all-words)
+                     '("abcd"))
+                   (super-new))))
+  (define f (new frame% [label ""]))
+  (define ec (new editor-canvas% [parent f] [editor t]))
+
+  (send t insert "pqr abc xyz")
+  (send t set-position 7 7)
+  (send t auto-complete)
+  (send ec on-char (new key-event%
+                        [key-code #\backspace]))
+  (send ec on-char (new key-event%
+                        [key-code #\return]))
+
+  (check-equal? (send t get-text) "pqr abcd xyz"))


### PR DESCRIPTION
If the backspace key has been pressed during autocompletion, some following characters would be unexpectedly deleted when the selected string is inserted, because the widen-possible-completions method doesn't adjust the value of word-end-pos. 