### PR TITLE
tex-table: more logical operators

### DIFF
--- a/tex-table/tex-table.rkt
+++ b/tex-table/tex-table.rkt
@@ -109,6 +109,8 @@
     ("pm" "±")
     ("cap" "∩")
     ("diamond" "◇")
+    ("lozenge" "◊")
+    ("square" "□")
     ("oplus" "⊕")
     ("mp" "∓")
     ("cup" "∪")
@@ -126,6 +128,9 @@
     ("sqcup" "⊔")
     ("vee" "∨")
     ("wedge" "∧")
+    ("lor" "∨")
+    ("land" "∧")
+    ("lnot" "¬")
     ("triangleleft" "◃")
     ("odot" "⊙")
     ("star" "★")
@@ -201,7 +206,17 @@
     ("ldots" "…")
     
     ("langle" "⟨")
-    ("rangle" "⟩")))
+    ("rangle" "⟩")
+
+    ("amp" "&")
+    ("invamp" "⅋")
+
+    ("multimap" "⊸")
+    ("leftmultimap" "⟜")
+    ("rightlollipop" "⊸")
+    ("leftlollipop" "⟜")
+    ("uplollipop" "⫯")
+    ("downlollipop" "⫰")))
 
 (module+ test
   (require racket/match)


### PR DESCRIPTION
This adds `\lnot`, `\land`, and `\lor` for propositional logic, `\lozenge` and `\square` for modal logic (`\lozenge` is used for Pollen as well), both kinds of ampersands for linear logic, and the lollipop connectives for linear logic and computability logic.