### PR TITLE
Update contract on image-snip% other-equal-to? method (racket/gui#119)

### DIFF
--- a/gui-doc/scribblings/gui/image-snip-class.scrbl
+++ b/gui-doc/scribblings/gui/image-snip-class.scrbl
@@ -121,7 +121,7 @@ If @racket[inline?] is not @racket[#f], the image data will be saved
 
 @history[#:changed "1.1" @elem{Added the @racket[backing-scale] argument.}]}
 
-@defmethod[(other-equal-to? [snip (is-a?/c image-snip%)]
+@defmethod[(other-equal-to? [snip (is-a?/c snip%)]
                             [equal? (any/c any/c . -> . boolean?)])
            boolean?]{
 

--- a/gui-test/tests/gracket/issue-119.rkt
+++ b/gui-test/tests/gracket/issue-119.rkt
@@ -1,8 +1,7 @@
-#lang racket
+#lang racket/base
+(require racket/gui pict pict/snip rackunit)
 
 ;; Check the fix for https://github.com/racket/gui/issues/119
-
-(require racket/gui pict pict/snip rackunit)
 (define s1 (make-object image-snip% (pict->bitmap (text "hello"))))
 (define s2 (make-object pict-snip% (text "hello")))
 (define s3 (make-object image-snip% (pict->bitmap (text "hello"))))

--- a/gui-test/tests/gracket/test.rkt
+++ b/gui-test/tests/gracket/test.rkt
@@ -6,3 +6,5 @@
 (load-relative "paramz.rktl")
 (load-relative "cache-image-snip-test.rktl")
 (load-relative "windowing.rktl")
+
+(require "./issue-119.rkt")

--- a/gui-test/tests/issue-119.rkt
+++ b/gui-test/tests/issue-119.rkt
@@ -1,0 +1,14 @@
+#lang racket
+
+;; Check the fix for https://github.com/racket/gui/issues/119
+
+(require racket/gui pict pict/snip rackunit)
+(define s1 (make-object image-snip% (pict->bitmap (text "hello"))))
+(define s2 (make-object pict-snip% (text "hello")))
+(define s3 (make-object image-snip% (pict->bitmap (text "hello"))))
+
+(check-true (equal? s1 s1))
+(check-false (equal? s1 s2))
+(check-false (equal? s2 s1)) ; this case used to report a contract violation
+(check-true (equal? s1 s3))
+(check-true (equal? s3 s1))


### PR DESCRIPTION
Update the signature of the `other-equal-to?` method for `image-snip%`, since
it now accepts a `snip%` as an argument.  Also added test cases for checking
that `image-snip%` objects can be compared with other objects.

This commit corresponds to the fix for issue #119, which is in the racket/snip
package.