### PR TITLE
add ctl-shift-z as redo in windows

### DIFF
--- a/gui-lib/framework/private/keymap.rkt
+++ b/gui-lib/framework/private/keymap.rkt
@@ -572,6 +572,8 @@
                     key)
                    func))])
       (add/map "editor-undo" 'undo "z")
+      (when (eq? (system-type) 'windows)
+        (add/map "editor-redo" 'redo "s:z"))
       (unless (eq? (system-type) 'macosx)
         (add/map "editor-redo" 'redo "y"))
       (add/map "editor-cut" 'cut "x")


### PR DESCRIPTION
This pull request is kind of just spit-balling; it looks to me like it should work, and it compiles on my mac, but

1) I haven't actually tried it on a Windows system (could maybe try this tonight), but more importantly,

2) I see that d:s:z works on macosx, but I can't see where that's specified in the source code; presumably, adding the c:s:z binding in Windows should be done in the same way that adding d:s:z is done for mac.

Can anyone point me to the place in the code where d:s:z is set up for the mac?