### PR TITLE
adds auto-delete for some characters created by auto-parens

### DIFF
--- a/gui-doc/scribblings/framework/color.scrbl
+++ b/gui-doc/scribblings/framework/color.scrbl
@@ -270,6 +270,15 @@
     editor.
 
   }
+  @defmethod[(get-matching-paren-string [paren-str string?]
+                                        [get-side (or/c 'open 'close 'either) 'either])
+             (or/c string? #f)]{
+    Returns a string of a paren matching the other side of @racket[paren-str] as specified
+    by the @racket[pairs] argument of @method[color:text<%> start-colorer], if one exists
+    on the side indicated by @racket[get-side]. If there is no match on the corresponding
+    side, including if @racket[paren-str] contains any characters other than a single paren
+    token (even whitespace), returns @racket[#f] instead.
+  }
   @defmethod[(skip-whitespace (position exact-nonnegative-integer?)
                               (direction (or/c 'forward 'backward))
                               (comments? boolean?))

--- a/gui-lib/framework/private/color.rkt
+++ b/gui-lib/framework/private/color.rkt
@@ -66,6 +66,8 @@ added get-regions
     
     is-lexer-valid?
     on-lexer-valid
+
+    get-matching-paren-string
     
     skip-whitespace
     backward-match
@@ -743,6 +745,21 @@ added get-regions
     (define/private (get-match-color) 
       (color-prefs:lookup-in-color-scheme 'framework:paren-match-color))
     
+    ;; See docs
+    ;; String Symbol -> (U String False)
+    (define/public (get-matching-paren-string paren-str [get-side 'either])
+      (define sym (string->symbol paren-str))
+      (define checker
+        (case get-side
+          [(either) (λ (x) (member sym x))]
+          [(open) (λ (x) (equal? sym (cadr x)))]
+          [(close) (λ (x) (equal? sym (car x)))]
+          [else (raise-argument-error 'get-matching-paren-string
+                                      "(or/c 'open 'close 'either)"
+                                      get-side)]))
+      (for/first ([pair (in-list pairs)]
+                  #:when (checker pair))
+        (symbol->string (car (remove sym pair)))))
     
     ;; higlight : number number number (or/c color any)
     ;;   if color is a color, then it uses that color to higlight

--- a/gui-test/framework/tests/color-text.rkt
+++ b/gui-test/framework/tests/color-text.rkt
@@ -222,3 +222,21 @@
   (send t thaw-colorer)
 
   (check-equal? (get-colors t) correct-result))
+
+(let ()
+  (define t (new color:text%))
+  (start-racket-colorer t)
+
+  (check-equal? (send t get-matching-paren-string "(") ")")
+  (check-equal? (send t get-matching-paren-string "(" 'close) ")")
+  (check-equal? (send t get-matching-paren-string "(" 'open) #f)
+  (check-equal? (send t get-matching-paren-string "]") "[")
+  (check-equal? (send t get-matching-paren-string "]" 'open) "[")
+  (check-equal? (send t get-matching-paren-string "{" 'either) "}")
+  (check-equal? (send t get-matching-paren-string "}" 'close) #f)
+  (check-exn exn:fail? (λ () (send t get-matching-paren-string "(" #f)))
+  (check-exn exn:fail? (λ () (send t get-matching-paren-string "(" 'forward)))
+  (check-equal? (send t get-matching-paren-string "[]") #f)
+  (check-equal? (send t get-matching-paren-string "} ") #f)
+  (check-equal? (send t get-matching-paren-string "") #f)
+  (check-equal? (send t get-matching-paren-string "abc") #f))


### PR DESCRIPTION
Addresses racket/drracket#201 regarding parens as well as analogous
behavior for " and | characters.