### PR TITLE
fix paren insertion at eol of line comment

### DIFF
--- a/gui-test/framework/tests/racket.rkt
+++ b/gui-test/framework/tests/racket.rkt
@@ -567,6 +567,16 @@
                            #\)
                            '(["[;)" "" "\n"]
                              ["[;)" "" "\n"]))
+(test-parens-behavior/full 'close-adjusts-properly-at-eol-of-line-comment
+                           "(;" "" "\n)"
+                           #\)
+                           '(["(;)" "" "\n)"]
+                             ["(;)" "" "\n)"]))
+(test-parens-behavior/full 'close-adjusts-properly-after-a-block-comment
+                           "(#||#" "" "\n)"
+                           #\)
+                           '(["(#||#)" "" "\n)"]
+                             ["(#||#\n)" "" ""]))
 (test-parens-behavior/full 'close-adjusts-properly-when-inside-an-unclosed-string
                            "[()\"" "" ""
                            #\)


### PR DESCRIPTION
This bug fix follows a discussion with Robby on slack #drracket. The bug was that when typing a closing parenthesis at the end of line of a line comment, smart-skip may skip to the next closing parenthesis on the next line, because the lexer believes it is already outside the line comment
(this behaviour is correct for nested comments `#|...|#` but not for line comments `; ...`). See the two new test cases.

The current proposal is a tradeoff between simplicity, bug fix, and specificity to the racket language.

Note that for homogeneity (and robustness), I also changed in the same function the previous check for beginning of strings and beginning of comments (where characters are actually not inserted in the string or comment) to follow the same pattern I use for the bug fix, which is to use the token start position rather than classifying left/right, which I believe is a more proper and robust way to check these cases. 

All tests from raco test in the gui root dir pass.

Happy to discuss this further, and thank you for your help on this.