### PR TITLE
Clean up misspelled string/text handling in `add-colorings`

### DIFF
--- a/gui-lib/framework/private/color.rkt
+++ b/gui-lib/framework/private/color.rkt
@@ -441,26 +441,27 @@ added get-regions
                                  sp
                                  query-aspell))
             (for ([spell-info (in-list spell-infos)])
-              (case (car spell-info)
+              (define maybe-suggestions (car spell-info))
+              (define start (list-ref spell-info 1))
+              (define end (list-ref spell-info 2))
+              (case maybe-suggestions
                 [(#f)
-                 (add-coloring/spell #f color (list-ref spell-info 1) (list-ref spell-info 2))]
+                 (add-coloring color start end)]
                 [else
-                 (add-coloring/spell (list-ref spell-info 0)
-                                     misspelled-color
-                                     (list-ref spell-info 1)
-                                     (list-ref spell-info 2))]))]
+                 (add-coloring misspelled-color start end)
+                 (add-suggestions maybe-suggestions
+                                  start
+                                  end)]))]
            [else
-            (add-coloring/spell #f color sp ep)])]
+            (add-coloring color sp ep)])]
         [else
-         (add-coloring/spell #f color sp ep)]))
+         (add-coloring color sp ep)]))
     
-    (define/private (add-coloring/spell suggestions color start end)
-      (add-coloring color start end)
-      (when suggestions
+    (define/private (add-suggestions suggestions start end)
+      (unless (= start end)
         (unless misspelled-regions
           (set! misspelled-regions (make-interval-map)))
-        (unless (= start end)
-          (interval-map-set! misspelled-regions start end suggestions))))
+        (interval-map-set! misspelled-regions start end suggestions)))
     (define misspelled-regions #f)
     (define/public (get-spell-suggestions position)
       (cond

--- a/gui-lib/framework/private/color.rkt
+++ b/gui-lib/framework/private/color.rkt
@@ -456,13 +456,11 @@ added get-regions
     
     (define/private (add-coloring/spell suggestions color start end)
       (add-coloring color start end)
-      (unless misspelled-regions
-        (when suggestions
-          (set! misspelled-regions (make-interval-map))))
-      (unless (= start end)
-        (when misspelled-regions
-          (when suggestions
-            (interval-map-set! misspelled-regions start end suggestions)))))
+      (when suggestions
+        (unless misspelled-regions
+          (set! misspelled-regions (make-interval-map)))
+        (unless (= start end)
+          (interval-map-set! misspelled-regions start end suggestions))))
     (define misspelled-regions #f)
     (define/public (get-spell-suggestions position)
       (cond


### PR DESCRIPTION
A prelude to modifying `add-colorings` to support https://github.com/racket/drracket/issues/367 .

Regardless of whether we touch that implementation, we could consider making `add-colorings` public, and then specialized sub-coloring could be mixed in. I happen to be working on some sub-colorings myself, which would benefit from having that api.