### PR TITLE
Fix spell checking

### DIFF
--- a/gui-lib/framework/private/color.rkt
+++ b/gui-lib/framework/private/color.rkt
@@ -447,19 +447,23 @@ added get-regions
       (or (and (equal? type 'string) spell-check-strings?)
           (and (equal? type 'text) spell-check-text?)))
     
+    ; This implementation (along with changes in the rest of the file) fixes spell-checking,
+    ;  which was only working before when used in a stereotyped way.
+    ;
+    ; Some notes about the properties of this implementation ...
+    ;
     ; The 7.7 docs specify that this method produces #f if checking is off (as well as if there are
     ;  no suggestions), although that behavior is unlikely to be usefully relied on in that case.
-    ;  The new implementation preserves that behavior.
+    ;  That behavior is preserved.
     ;
-    ; The new implementation relies on the colorer not being stopped, and produces #f if it is.
+    ; The method needs information from the colorer, and produces #f if the colorer is stopped.
     ;
-    ; The previous implementation attempted to initiate and then maintain a set of misspelled regions
-    ;  based on an initial coloring, but was fundamentally broken, unless used in a stereotyped way.
-    ;  It also had the property (arguably a bug, although mild and obscure) of requiring the style
-    ;  list have a style for misspelled colors. That incidental property isn't preserved here.
+    ; Coloring misspelled words requires that the style list have a style for misspelled colors,
+    ;  but this method does not. So, although unlikely, if that style is missing one can still
+    ;  interact with spell checking (skip to, suggest correction, replace).
     ;
-    ; Although private members are used, the implementation can easily access them via this mixin's
-    ;  public api and be made independent of its implementation.
+    ; The method uses private members of this mixin, but those could easily be accessed via
+    ;  the public api and the method could be made independent of the mixin's implementation.
     ;
     (define/public (get-spell-suggestions position)
       (define-syntax-rule (cond/#f [condition body ...]) (cond [condition body ...] [else #f]))

--- a/gui-lib/framework/private/color.rkt
+++ b/gui-lib/framework/private/color.rkt
@@ -1380,31 +1380,26 @@ added get-regions
                            current-dict
                            sp
                            maybe-query-aspell)
-  (define strs (regexp-split #rx"\n" newline-str))
-  (define answer '())
-  (let loop ([strs strs]
-             [pos sp])
-    (unless (null? strs)
-      (define str (car strs))
-      (let loop ([spellos (maybe-query-aspell str current-dict)]
-                 [lp 0])
-        (cond
-          [(null? spellos)
-           (set! answer (cons (list #f (+ pos lp) (+ pos (string-length str))) answer))]
-          [else
-           (define err (car spellos))
-           (define err-start (list-ref err 0))
-           (define err-len (list-ref err 1))
-           (define suggestions (list-ref err 2))
-           (set! answer
-                 (list* 
-                  (list suggestions (+ pos err-start) (+ pos err-start err-len))
-                  (list #f (+ pos lp) (+ pos err-start))
-                  answer))
-           (loop (cdr spellos) (+ err-start err-len))]))
-      (loop (cdr strs)
-            (+ pos (string-length str) 1))))
-  answer)
+  (for/fold
+   ([answer '()]
+    [pos sp]
+    #:result answer)
+   ([str (in-list (regexp-split #rx"\n" newline-str))])
+    (values
+     (for/fold
+      ([answer answer]
+       [lp 0]
+       #:result (cons (list #f (+ pos lp) (+ pos (string-length str))) answer))
+      ([err (in-list (maybe-query-aspell str current-dict))])
+       (define err-start (list-ref err 0))
+       (define err-len (list-ref err 1))
+       (define suggestions (list-ref err 2))
+       (values (list* 
+                (list suggestions (+ pos err-start) (+ pos err-start err-len))
+                (list #f (+ pos lp) (+ pos err-start))
+                answer) 
+               (+ err-start err-len)))
+     (+ pos (string-length str) 1))))
 
 (module+ test
   (require rackunit racket/list racket/pretty


### PR DESCRIPTION
New approach that Identifies spelling suggestions for clients by rechecking the token at the requested position, rather than trying to track shifting regions created when misspellings are colored.

The former implementation was buggy when misspelled regions changed token type or were edited without completely being replaced. A correct implementation following its approach would still be tricky, and prone to efficiency costs that the new approach shifts completely to when the user requests the location of a misspelled word or its suggestions.

The user now only pays for spell check features (find misspelled word, request suggestions) when used (and which is rare compared to general editing and recoloring). Moreover, the overhead is negligible relative to the user's interaction time with the feature (context switch, menu selection or keypress, consideration of and reaction to the result).