### PR TITLE
Partially fixes #185

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Racket compiled files
 compiled/
+doc/
 
 # common backups, autosaves, lock files, OS meta-files
 *~

--- a/gui-doc/scribblings/framework/color.scrbl
+++ b/gui-doc/scribblings/framework/color.scrbl
@@ -370,7 +370,7 @@
     This method must be called only when the tokenizer is started.
   }
 
-  @defmethod[#:mode augment (on-lexer-valid [valid? boolean?]) any]{
+  @defmethod[#:mode pubment (on-lexer-valid [valid? boolean?]) any]{
     This method is an observer for when the lexer is working.  It is called
     when the lexer's state changes from valid to invalid (and back).  The
     @racket[valid?] argument indicates if the lexer has finished running over

--- a/gui-doc/scribblings/framework/frame.scrbl
+++ b/gui-doc/scribblings/framework/frame.scrbl
@@ -891,18 +891,18 @@
   }
 
   @defmethod*[#:mode override
-              (((edit-menu:find-again-callback (item (is-a?/c menu-item%))
+              (((edit-menu:find-next-callback (item (is-a?/c menu-item%))
                                                (evt (is-a?/c control-event%)))
                 void?))]{
     Calls @method[frame:searchable unhide-search] and then
     @method[frame:searchable<%> search].
   }
 
-  @defmethod*[#:mode override (((edit-menu:create-find-again?) boolean?))]{
+  @defmethod*[#:mode override (((edit-menu:create-find-next?) boolean?))]{
     returns @racket[#t].
   }
 
-  @defmethod*[#:mode override (((edit-menu:find-again-backwards-callback
+  @defmethod*[#:mode override (((edit-menu:find-previous-callback
                                  (item (is-a?/c menu-item%))
                                  (evt (is-a?/c control-event%)))
                                 void?))]{
@@ -910,7 +910,7 @@
     @method[frame:searchable<%> search].
   }
 
-  @defmethod*[#:mode override (((edit-menu:create-find-again-backwards?) boolean?))]{
+  @defmethod*[#:mode override (((edit-menu:create-find-previous?) boolean?))]{
     returns @racket[#t].
   }
 

--- a/gui-doc/scribblings/framework/racket.scrbl
+++ b/gui-doc/scribblings/framework/racket.scrbl
@@ -114,7 +114,7 @@
            #:changed "1.26" @list{Added the @racket[get-head-sexp-type] argument.}]
   }
 
- @defmethod[#:mode augment
+ @defmethod[#:mode pubment
             (compute-amount-to-indent [pos exact-nonnegative-integer?])
             exact-nonnegative-integer?]{
   Computes the amount of space to indent the line containing @racket[pos].


### PR DESCRIPTION
- Use `pubment` for `on-lexer-valid` and `compute-amount-to-indent`
- Rename `find-again` to `find-next` and `find-previous`, following the changes
  at https://github.com/racket/gui/commit/5d4394a043172dcd13347db41af8b7d058f31d9f

CC: @rfindler 