### PR TITLE
Ensure that the canvas width is sufficient for reflowing lines (fix for #192)

### DIFF
--- a/gui-lib/mred/private/wxme/text.rkt
+++ b/gui-lib/mred/private/wxme/text.rkt
@@ -4935,14 +4935,14 @@
               (loop (mline-next line)))))
         
         (let ([-changed?
-               (if (max-width . > . 0)
-                   (let ([wl? write-locked?]
-                         [fl? flow-locked?])
-                     ;; if any flow is updated, snip sizing methods will be called
-                     (set! write-locked? #t)
-                     (set! flow-locked? #t)
-                     
-                     (let ([w (- max-width padding-l padding-t CURSOR-WIDTH)])
+               (let ([w (- max-width padding-l padding-t CURSOR-WIDTH)])
+                 (if (w . > . 0)
+                     (let ([wl? write-locked?]
+                           [fl? flow-locked?])
+                       ;; if any flow is updated, snip sizing methods will be called
+                       (set! write-locked? #t)
+                       (set! flow-locked? #t)
+                       
                        (let loop ([-changed? #f])
                          (if (begin0
                               (mline-update-flow (unbox line-root-box) line-root-box this w dc
@@ -4963,8 +4963,8 @@
                              (begin
                                (set! flow-locked? fl?)
                                (set! write-locked? wl?)
-                               -changed?)))))
-                   #f)])
+                               -changed?))))
+                     #f))])
 
           (when (not (= max-width old-max-width))
             (set! max-width old-max-width))

--- a/gui-test/tests/gracket/pr195.rkt
+++ b/gui-test/tests/gracket/pr195.rkt
@@ -1,0 +1,21 @@
+#lang racket/gui
+
+;; Test case for https://github.com/racket/gui/pull/195, note that with the
+;; bug present, this code should hang and not terminate.
+
+(define frame
+  (new frame% [label "my frame"] [width 400] [height 300]))
+
+(define canvas (new editor-canvas% [parent frame]))
+(define text (new text%))
+
+(send canvas set-editor text) ;; won't hang if this is called below
+
+(send text auto-wrap #t)
+(send text set-padding 10 10 10 10) ;; hangs here
+
+;; (send canvas set-editor text) ;; won't hang if this is called here
+
+(send frame show #t)
+(sleep/yield 0.5)
+(send frame show #f)


### PR DESCRIPTION
This is a fix for #192, and the example in that issue works fine with this change.

## Explanation

Calling `set-padding`, will result in a call to `recalc-lines` (via calls to `needs-update` -> `continue-update` -> `redraw`).

Before the `text%` objects is shown and the canvas dimensions are computed, the `max-width` will be 3, and when the left, right padding and `CURSOR-WIDTH` are subtracted from it, the remaining width will be negative.  As a result of this, `mline-update-flow` will always return `#t`, so the loop never terminates.

I changed the code to calculate the final width and checking that result to be positive.

## Things I still don't understand

* I am unsure why `max-width` was 3 before the canvas was shown (using the example from #192), I was expecting it to be 0
* ~I could not find the definition of `mline-update-flow` using a GitHub search, so I don't know where that function is defined.~  -- I found the definition.  It is in mline.rkt under the name `update-flow`.
* The check for the width is still to be greater than 0, which is what the original code did, but I am unsure if the loop will terminate when the width is a very small value, for example when someone sets a big padding, such that the remaining width is 1.   I think an improvement would be not only to check if `mline-update-flow` needs further re-flows, but also if anything changed since the last re-flow (that is, to see if a re-flow is in fact possible at all).

Still, at least the case described in #192 is fixed by this pull request.
