### PR TITLE
Enable writing markup to text:ports-mixin texts:

### DIFF
--- a/gui-doc/scribblings/framework/frame.scrbl
+++ b/gui-doc/scribblings/framework/frame.scrbl
@@ -557,6 +557,11 @@
   @defmethod*[(((get-editor) (is-a?/c editor<%>)))]{
     Returns the editor in this frame.
   }
+
+  @defmethod*[(((find-editor (predicate ((is-a?/c editor<%>) . -> . boolean?)))
+  			      (or/c (is-a?/c editor<%>) #f)))]{
+    Finds an editor matching the predicate, or returns @racket[#f] if there isn't any.
+  }
 }
 @defmixin[frame:editor-mixin (frame:standard-menus<%>) (frame:editor<%>)]{
   This mixin adds functionality to support an 

--- a/gui-doc/scribblings/framework/framework.scrbl
+++ b/gui-doc/scribblings/framework/framework.scrbl
@@ -112,6 +112,7 @@ the @secref["editor-snip"] section.
 @include-section["preferences.scrbl"]
 @include-section["preferences-text.scrbl"]
 @include-section["racket.scrbl"]
+@include-section["srcloc-snip.scrbl"]
 @include-section["text.scrbl"]
 @include-section["splash.scrbl"]
 @include-section["test.scrbl"]

--- a/gui-doc/scribblings/framework/srcloc-snip.scrbl
+++ b/gui-doc/scribblings/framework/srcloc-snip.scrbl
@@ -1,0 +1,26 @@
+#lang scribble/doc
+@(require scribble/manual scribble/extract)
+@(require (for-label framework))
+@(require (for-label scheme/gui))
+@title{Srcloc Snips}
+
+@defclass[srcloc-snip:snip% editor-snip% ()]{
+This snip implements clickable links to @racket[srcloc] locations.
+
+The snip is initialized with an appropriate editor, into which a
+representation for the link can be inserted.  When the reprenstation
+has been inserted, the @racket[activate-link] method needs to be
+called to activate the link.
+     
+@defconstructor[([srcloc srcloc?])]{
+ The @racket[srcloc] field specifies where the link points.
+}
+
+@defmethod[#:mode public (activate-link) void?]{
+ This makes the content of the snip's editor clickable, such that
+ clicking highlights the position of the srcloc.
+}
+}
+
+@(include-previously-extracted "main-extracts.rkt" #rx"^srcloc-snip:")
+

--- a/gui-doc/scribblings/framework/text.scrbl
+++ b/gui-doc/scribblings/framework/text.scrbl
@@ -1346,6 +1346,11 @@
 
 @defmixin[text:ports-mixin (text:wide-snip<%>) (text:ports<%>)]{
 
+  The ports from this mixin accepts as special values (see
+  @racket[port-writes-special?]) markup from the
+  @racketmodname[simple-tree-text-markup/data] module, and renders
+  them with graphical boxes and clickable srcloc links.
+
   @defmethod*[#:mode augment (((can-insert? (start exact-integer?) (len exact-integer?)) boolean?))]{
     Returns the results of the @racket[inner] call, unless
     @method[text:ports<%> get-allow-edits] returns @racket[#f].

--- a/gui-lib/framework/framework-unit.rkt
+++ b/gui-lib/framework/framework-unit.rkt
@@ -7,6 +7,7 @@
          "private/text-sig.rkt"
          "private/number-snip.rkt"
          "private/comment-box.rkt"
+         "private/srcloc-snip.rkt"
          "private/application.rkt"
          "private/version.rkt"
          "private/color-model.rkt"
@@ -55,6 +56,7 @@
           framework:color^
           framework:color-prefs^
           framework:comment-box^
+          framework:srcloc-snip^
           framework:finder^
           framework:group^ 
           framework:canvas^
@@ -67,7 +69,7 @@
    preferences@ early-init@
    application@ version@ color-model@ mode@ exit@ menu@
    number-snip@ autosave@ path-utils@ icon@ keymap@
-   editor@ pasteboard@ text@ color@ color-prefs@ comment-box@ 
+   editor@ pasteboard@ text@ color@ color-prefs@ comment-box@ srcloc-snip@
    finder@ group@ canvas@ panel@ frame@ handler@ racket@ main@))
 
 (define-unit/new-import-export framework@ (import mred^) (export framework^)
@@ -89,6 +91,7 @@
     (prefix color: framework:color^)
     (prefix color-prefs: framework:color-prefs^)
     (prefix comment-box: framework:comment-box^)
+    (prefix srcloc-snip: framework:srcloc-snip^)
     (prefix finder: framework:finder^)
     (prefix group: framework:group^)
     (prefix canvas: framework:canvas^)

--- a/gui-lib/framework/main.rkt
+++ b/gui-lib/framework/main.rkt
@@ -52,6 +52,7 @@
  (prefix color: framework:color-class^)
  (prefix color-prefs: framework:color-prefs-class^)
  (prefix comment-box: framework:comment-box-class^)
+ (prefix srcloc-snip: framework:srcloc-snip-class^)
  (prefix finder: framework:finder-class^)
  (prefix group: framework:group-class^)
  (prefix canvas: framework:canvas-class^)

--- a/gui-lib/framework/private/frame.rkt
+++ b/gui-lib/framework/private/frame.rkt
@@ -1401,7 +1401,9 @@
                      save
                      save-as
                      get-canvas
-                     get-editor))
+                     get-editor
+
+                     find-editor))
 
 (define editor-mixin
   (mixin (standard-menus<%>) (-editor<%>)
@@ -1629,7 +1631,11 @@
         (set! editor (make-editor))
         (send (get-canvas) set-editor editor))
       editor)
-    
+    (define/public (find-editor predicate)
+      (if (and editor
+               (predicate editor))
+          editor
+          #f))
     (cond
       [(and filename (file-exists? filename))
        (let ([ed (get-editor)])

--- a/gui-lib/framework/private/sig.rkt
+++ b/gui-lib/framework/private/sig.rkt
@@ -19,7 +19,13 @@
     (snip%))
   (define-signature comment-box^ extends comment-box-class^
     (snipclass))
-  
+
+  (define-signature srcloc-snip-class^
+    (snip%))
+  (define-signature srcloc-snip^ extends srcloc-snip-class^
+    (snipclass
+     select-srcloc))
+
   (define-signature menu-class^
     (can-restore<%>
      can-restore-mixin
@@ -469,6 +475,7 @@
      (open (prefix color: color^))
      (open (prefix color-prefs: color-prefs^))
      (open (prefix comment-box: comment-box^))
+     (open (prefix srcloc-snip: srcloc-snip^))
      (open (prefix finder: finder^))
      (open (prefix group: group^))
      (open (prefix canvas: canvas^))

--- a/gui-lib/framework/private/srcloc-snip.rkt
+++ b/gui-lib/framework/private/srcloc-snip.rkt
@@ -1,0 +1,131 @@
+#lang racket/base
+
+(require racket/unit
+         racket/class
+         racket/gui/base
+         racket/snip
+         "sig.rkt"
+         (prefix-in base: racket/base))
+
+(provide srcloc-snip@)
+
+(define-unit srcloc-snip@
+  (import [prefix frame: framework:frame^]
+          [prefix group: framework:group^]
+          [prefix text: framework:text^]
+          [prefix editor: framework:editor^])
+  (export (rename framework:srcloc-snip^ [-snip% snip%]))
+
+  (define (select-srcloc srcloc)
+    (let frame-loop ([frames (send (group:get-the-frame-group) get-frames)])
+      (unless (null? frames)
+        (let ([frame (car frames)])
+          (cond
+            [(and (is-a? frame frame:editor<%>)
+                  (send frame find-editor
+                        (lambda (editor)
+                          (send editor port-name-matches? (srcloc-source srcloc)))))
+             => (lambda (editor)
+                  (show-editor frame editor)
+                  (send (send frame get-interactions-text)
+                        highlight-error
+                        editor (srcloc-position srcloc) (+ (srcloc-position srcloc) (srcloc-span srcloc))))]
+            [else
+             (frame-loop (cdr frames))])))))
+
+  (define (show-editor frame editor)
+    (let* ([current-tab (send editor get-tab)]
+           [frame (send current-tab get-frame)])
+      (let loop ([tabs (send frame get-tabs)] [i 0])
+        (unless (null? tabs)
+          (if (eq? (car tabs) current-tab)
+              (send frame change-to-nth-tab i)
+              (loop (cdr tabs) (+ i 1)))))
+      (send frame show #t)))
+
+  ; honest attempt
+  (define (source->datum source)
+    (if (path? source)
+        (path->bytes source)
+        source))
+
+  (define (datum->source source)
+    (if (bytes? source)
+        (bytes->path source)
+        source))
+  
+  (define srcloc-snip-class%
+    (class snip-class%
+      (inherit set-version set-classname)
+      (super-new)
+      (set-version 1)
+      (set-classname (format "~s" '((lib "srcloc-snip.rkt" "framework")
+                                    (lib "wxme-srcloc-snip.rkt" "framework"))))
+      ; serialize as (srcloc <source> <line> <column> <position> <span>) <text>
+      (define/override (read f)
+        (with-handlers ([exn? (lambda (exn) #f)])
+          (let* ((bytes (send f get-unterminated-bytes))
+                 (port (open-input-bytes bytes 'srcloc))
+                 (datum (base:read port))
+                 (srcloc (apply
+                          (lambda (_ source line column position span)
+                            (srcloc (datum->source source) line column position span))
+                          datum))
+                 (snip
+                  (new -snip% [srcloc srcloc]))
+                 (editor (send snip get-editor)))
+            (send editor read-from-file f #t)
+            (send snip activate-link)
+            snip)))))
+
+  (define snipclass (new srcloc-snip-class%))
+  (send (get-the-snip-class-list) add snipclass)
+
+  ;; class for snips embedded in markup
+  (define markup-text%
+    (text:wide-snip-mixin
+     (text:basic-mixin
+      (editor:standard-style-list-mixin
+       (editor:basic-mixin
+        text%)))))
+  
+  (define -snip%
+    (class editor-snip%
+      (init-field srcloc)
+      (inherit set-snipclass
+               use-style-background
+               get-editor)
+      (super-new [editor (new markup-text%)]
+                 [with-border? #f])
+      (set-snipclass snipclass)
+
+      ; you must call this after having put something in the editor
+      (define/public (activate-link)
+        (let ((editor (get-editor)))
+          (send editor set-clickback
+                0 (send editor get-end-position)
+                (lambda (t s e)
+                  (select-srcloc srcloc))
+                #f #f)
+          (send editor lock #t)))
+      
+      (use-style-background #t)
+      
+      
+      (define/override (copy)
+        (let ((snip (new -snip% [srcloc srcloc])))
+          (send (get-editor) copy-self-to (send snip get-editor))
+          (send snip activate-link)
+          snip))
+      
+      (define/override (write f)
+        (let ((port (open-output-string))
+              (sexpr `(srcloc ,(source->datum (srcloc-source srcloc))
+                              ,(srcloc-line srcloc)
+                              ,(srcloc-column srcloc)
+                              ,(srcloc-position srcloc)
+                              ,(srcloc-span srcloc))))
+          (base:write sexpr port)
+          (let ((bytes (get-output-bytes port)))
+            (send f put (bytes-length bytes) bytes))
+          (send (get-editor) write-to-file f))))))

--- a/gui-lib/framework/private/text.rkt
+++ b/gui-lib/framework/private/text.rkt
@@ -16,6 +16,7 @@
          "text-search.rkt"
          "text-inline-overview.rkt"
          "text-sig.rkt"
+         "srcloc-snip.rkt"
          "sig.rkt")
 
 (provide text@)
@@ -30,7 +31,8 @@
           [frame : framework:frame^]
           [racket : framework:racket^]
           [number-snip : framework:number-snip^]
-          [finder : framework:finder^])
+          [finder : framework:finder^]
+          [srcloc-snip : framework:srcloc-snip^])
 
   (export text-ascii-art^
           text-autocomplete^
@@ -71,6 +73,7 @@
           framework:racket^
           framework:number-snip^
           (prefix finder: framework:finder^)
+          framework:srcloc-snip^
           )
   (export framework:text^)
   ((text-ascii-art^
@@ -96,4 +99,5 @@
    (prefix frame: framework:frame^)
    framework:racket^
    framework:number-snip^
-   (prefix finder: framework:finder^)))
+   (prefix finder: framework:finder^)
+   framework:srcloc-snip^))

--- a/gui-lib/framework/srcloc-snip.rkt
+++ b/gui-lib/framework/srcloc-snip.rkt
@@ -1,0 +1,4 @@
+#lang racket/base
+(require framework)
+  
+(provide (rename-out [comment-box:snipclass snip-class]))

--- a/gui-lib/framework/wxme-srcloc-snip.rkt
+++ b/gui-lib/framework/wxme-srcloc-snip.rkt
@@ -1,0 +1,58 @@
+#lang racket/base
+(require racket/class
+         racket/format
+         wxme
+         wxme/private/readable-editor)
+
+(provide reader)
+
+(define (datum->source source)
+  (if (bytes? source)
+      (bytes->path source)
+      source))
+
+(define (datum->source-expression source)
+  (if (path? source)
+      `(bytes->path ,(path->bytes source))
+      `',source))
+
+(define (srcloc->expression srcloc)
+  `(srcloc
+    ,(datum->source-expression (srcloc-source srcloc))
+    ,(srcloc-line srcloc)
+    ,(srcloc-column srcloc)
+    ,(srcloc-position srcloc)
+    ,(srcloc-span srcloc)))
+
+(define editor-reader (new editor-reader%))
+
+(define srcloc-snip-reader%
+  (class* object% (snip-reader<%>)
+    (define/public (read-header version stream) (void))
+    (define/public (read-snip text-only? version stream)
+      (let* ((bytes (send stream read-raw-bytes "srcloc"))
+             (port (open-input-bytes bytes 'srcloc))
+             (datum (read port))
+             (srcloc (apply
+                      (lambda (_ source line column position span)
+                        (srcloc (datum->source source) line column position span))
+                      datum))
+             (editor (send editor-reader read-snip text-only? version stream))) ; don't need this
+      (cond
+        [text-only?
+         (string->bytes/utf-8 (~s (srcloc->expression srcloc)))]
+        [else
+         (new srcloc-readable [srcloc srcloc])])))
+    (super-new)))
+
+(define srcloc-readable
+  (class* object% (readable<%>)
+    (init-field srcloc)
+    (define/public (read-special source line column position)
+      (datum->syntax #f
+                     (srcloc->expression srcloc)
+                     (vector source line column position 1)
+                     #f))
+    (super-new)))
+
+(define reader (new srcloc-snip-reader%))

--- a/gui-lib/info.rkt
+++ b/gui-lib/info.rkt
@@ -18,6 +18,7 @@
                "2d-lib"
                "compatibility-lib"
                "tex-table"
+               "simple-tree-text-markup-lib"
                ("gui-i386-macosx" #:platform "i386-macosx")
                ("gui-x86_64-macosx" #:platform "x86_64-macosx" #:version "1.3")
                ("gui-ppc-macosx" #:platform "ppc-macosx")


### PR DESCRIPTION
- make text:ports-mixin port accept markup objects as special values
- add srcloc-snip% class to create clickable links
- add find-editor method to frame:editor<%> for use in above

NOTE: Needs to be applied together with the pull request coming up for `drracket`