### PR TITLE
Updated documentation of default snip insert location

### DIFF
--- a/gui-doc/scribblings/gui/pasteboard-class.scrbl
+++ b/gui-doc/scribblings/gui/pasteboard-class.scrbl
@@ -682,7 +682,7 @@ Inserts @racket[snip] at @techlink{location} @math{(@racket[x],
  @racket[before]. (@|seesniporderdiscuss|) If @racket[before] is not
  provided or is @racket[#f], then @racket[snip] is inserted behind all
  other snips. If @racket[x] and @racket[y] are not provided, the snip
- is added at @math{(0, 0)}.
+ is added at the center of the pasteboard.
 
 }
 


### PR DESCRIPTION
The default insert location of a snip on a pasteboard was incorrectly documented as (0,0), whereas the behavior is that the snip is inserted at the center of the pasteboard. See https://github.com/racket/gui/blob/7c3533424f01fc667d5ec0f7598614f367892eac/gui-lib/mred/private/wxme/pasteboard.rkt#L712