### PR TITLE
guard mouse-event

### DIFF
--- a/gui-lib/mred/private/wxwindow.rkt
+++ b/gui-lib/mred/private/wxwindow.rkt
@@ -171,7 +171,8 @@
                  (if (eq? w orig-w)
                      (k (wx->proxy w) e)
                      (cond
-                       [(memq (send e get-event-type) '(enter leave))
+                       [(and (is-a? e wx:mouse-event%)
+                             (memq (send e get-event-type) '(enter leave)))
                         ;; suppress enter and leave events
                         #f]
                        [else


### PR DESCRIPTION
guard from using mouse-event methods on a key-event

close [drracket/issues/466](https://github.com/racket/drracket/issues/466)