### PR TITLE
Add option in  that controls Home and End. Default unchanged.

### DIFF
--- a/gui-lib/framework/private/keymap-global.rkt
+++ b/gui-lib/framework/private/keymap-global.rkt
@@ -520,7 +520,38 @@
                         "delete-next-character"
                         "delete-previous-character")
                     edit event #t)))]
-         
+         [home-key          
+          (λ (edit event)
+            (let ([kmap (send edit get-keymap)])
+              (send kmap call-function
+                    (if (preferences:get 'framework:home/end-to-beginning/end-of-document?)
+                        "beginning-of-file"
+                        "beginning-of-line")
+                    edit event #t)))]
+         [end-key
+          (λ (edit event)
+            (let ([kmap (send edit get-keymap)])
+              (send kmap call-function
+                    (if (preferences:get 'framework:home/end-to-beginning/end-of-document?)
+                        "end-of-file"
+                        "end-of-line")
+                    edit event #t)))]
+         [shift-home-key          
+          (λ (edit event)
+            (let ([kmap (send edit get-keymap)])
+              (send kmap call-function
+                    (if (preferences:get 'framework:home/end-to-beginning/end-of-document?)
+                        "select-to-beginning-of-file"
+                        "select-to-beginning-of-line")
+                    edit event #t)))]
+         [shift-end-key
+          (λ (edit event)
+            (let ([kmap (send edit get-keymap)])
+              (send kmap call-function
+                    (if (preferences:get 'framework:home/end-to-beginning/end-of-document?)
+                        "select-to-end-of-file"
+                        "select-to-end-of-line")
+                    edit event #t)))]         
          [toggle-overwrite
           (λ (edit event)
             (when (preferences:get 'framework:overwrite-mode-keybindings)
@@ -813,6 +844,10 @@
         (add-m "select-click-line" select-click-line)
         
         (add "delete-key" delete-key)
+        (add "home-key" home-key)
+        (add "end-key" end-key)
+        (add "shift-home-key" shift-home-key)
+        (add "shift-end-key" shift-end-key)
         
         (add "mouse-popup-menu" mouse-popup-menu)
         
@@ -883,15 +918,15 @@
         
         (map "c:e" "end-of-line")
         (map "d:right" "end-of-line")
-        (map "end" "end-of-line")
-        (map "s:end" "select-to-end-of-line")
+        (map "end" "end-key")
+        (map "s:end" "shift-end-key")
         (map "s:c:e" "select-to-end-of-line")
         (map "s:d:right" "select-to-end-of-line")
         
         (map "c:a" "beginning-of-line")
         (map "d:left" "beginning-of-line")
-        (map "home" "beginning-of-line")
-        (map "s:home" "select-to-beginning-of-line")
+        (map "home" "home-key")
+        (map "s:home" "shift-home-key")
         (map "s:c:a" "select-to-beginning-of-line")
         (map "s:d:left" "select-to-beginning-of-line")
         

--- a/gui-lib/framework/private/main.rkt
+++ b/gui-lib/framework/private/main.rkt
@@ -560,6 +560,7 @@
 
 (preferences:set-default 'framework:verify-exit #t boolean?)
 (preferences:set-default 'framework:delete-forward? #t boolean?)
+(preferences:set-default 'framework:home/end-to-beginning/end-of-document? #f boolean?)
 (preferences:set-default 'framework:show-periods-in-dirlist #f boolean?)
 (preferences:set-default 'framework:file-dialogs 'std
                          (λ (x) (and (memq x '(common std)) #t)))

--- a/gui-lib/framework/private/preferences.rkt
+++ b/gui-lib/framework/private/preferences.rkt
@@ -465,6 +465,8 @@ the state transitions / contracts are:
                    (add-check editor-panel 'framework:delete-forward?
                               (string-constant map-delete-to-backspace)
                               not not)
+                   (add-check editor-panel 'framework:home/end-to-beginning/end-of-document?
+                              (string-constant home/end-is-go-to-beginning/end-of-document))
                    (add-check editor-panel 
                               'framework:auto-set-wrap?
                               (string-constant wrap-words-in-editor-buffers))


### PR DESCRIPTION
This PR adds a new option in "Editing | General Editing".

The conventions on macOS differ from Windows/Linux when it comes 
the handling of the Home and End keys. On macOs they are move
to the beginning and end of the document, on the other systems to
the beginning and end of the line.

If the new option is checked, the macOS convention is used.
The option also affects shift+Home/End.

The default value is set of false. Should this default to true on macOS?

![image](https://user-images.githubusercontent.com/461765/112729383-1777eb00-8f2c-11eb-8846-3d5568c2f58e.png)
