### PR TITLE
list-box: fix cell higlighting on macOS

### DIFF
--- a/gui-lib/mred/private/wx/cocoa/list-box.rkt
+++ b/gui-lib/mred/private/wx/cocoa/list-box.rkt
@@ -42,13 +42,6 @@
 (define-objc-class RacketTableView NSTableView
   #:mixins (FocusResponder KeyMouseResponder CursorDisplayer)
   [wxb]
-  [-a _id (preparedCellAtColumn: [_NSInteger column] row: [_NSInteger row])
-      (define wx (->wx wxb))
-      (define font (and wx (send wx get-cell-font)))
-      (define cell (super-tell preparedCellAtColumn: #:type _NSInteger column row: #:type _NSInteger row))
-      (tellv cell setLineBreakMode: #:type _NSUInteger NSLineBreakByTruncatingTail)
-      (when font (tellv cell setFont: font))
-      cell]
   [-a _void (doubleClicked: [_id sender])
       (queue-window*-event wxb (lambda (wx) (send wx clicked 'list-box-dclick)))]
   [-a _void (tableViewSelectionDidChange: [_id aNotification])
@@ -66,13 +59,16 @@
   [-a _NSInteger (numberOfRowsInTableView: [_id view])
       (let ([wx (->wx wxb)])
         (send wx number))]
-  [-a _NSString (tableView: [_id aTableView]
-                            objectValueForTableColumn: [_id aTableColumn]
-                            row: [_NSInteger rowIndex])
-      (let ([wx (->wx wxb)])
-        (if wx
-            (send wx get-cell aTableColumn rowIndex)
-            "???"))])
+  [-a _id (tableView: [_id aTableView]
+                      objectValueForTableColumn: [_id aTableColumn]
+                      row: [_NSInteger rowIndex])
+      (define wx (->wx wxb))
+      (define text (if wx (send wx get-cell aTableColumn rowIndex) "???"))
+      (define cell (tell (tell NSCell alloc) initTextCell: #:type _NSString text))
+      (define font (and wx (send wx get-cell-font)))
+      (tellv cell setLineBreakMode: #:type _NSUInteger NSLineBreakByTruncatingTail)
+      (when font (tellv cell setFont: font))
+      (tell cell autorelease)])
 
 (define (remove-nth data i)
   (cond

--- a/gui-lib/mred/private/wx/cocoa/list-box.rkt
+++ b/gui-lib/mred/private/wx/cocoa/list-box.rkt
@@ -43,16 +43,12 @@
   #:mixins (FocusResponder KeyMouseResponder CursorDisplayer)
   [wxb]
   [-a _id (preparedCellAtColumn: [_NSInteger column] row: [_NSInteger row])
-      (let ([wx (->wx wxb)])
-        (tell
-         (let ([c (tell (tell NSCell alloc) initTextCell: #:type _NSString 
-                        (if wx (send wx get-cell column row) "???"))]
-               [font (and wx (send wx get-cell-font))])
-           (tellv c setLineBreakMode: #:type _NSUInteger NSLineBreakByTruncatingTail)
-           (when font
-             (tellv c setFont: font))
-           c)
-         autorelease))]
+      (define wx (->wx wxb))
+      (define font (and wx (send wx get-cell-font)))
+      (define cell (super-tell preparedCellAtColumn: #:type _NSInteger column row: #:type _NSInteger row))
+      (tellv cell setLineBreakMode: #:type _NSUInteger NSLineBreakByTruncatingTail)
+      (when font (tellv cell setFont: font))
+      cell]
   [-a _void (doubleClicked: [_id sender])
       (queue-window*-event wxb (lambda (wx) (send wx clicked 'list-box-dclick)))]
   [-a _void (tableViewSelectionDidChange: [_id aNotification])


### PR DESCRIPTION
Here's what the following program looks like

```racket
#lang racket/gui

(define f (new frame% [label "LB"]))
(define l (new list-box% [parent f] [label #f] [choices '("a" "b")]))
(send f show #t)
```

before this change:

<img width="148" alt="Screenshot 2021-06-12 at 10 43 25" src="https://user-images.githubusercontent.com/43347/121769219-09208f00-cb6b-11eb-80a4-0c77287274f7.png">

and after:

<img width="148" alt="Screenshot 2021-06-12 at 10 42 43" src="https://user-images.githubusercontent.com/43347/121769223-0d4cac80-cb6b-11eb-8d1b-33a56e387ac2.png">
