### PR TITLE
Increase view used while printing

### DIFF
--- a/gui-lib/mred/private/wxme/editor-canvas.rkt
+++ b/gui-lib/mred/private/wxme/editor-canvas.rkt
@@ -1220,6 +1220,7 @@
       (send canvas get-dc-and-offset fx fy)]))
 
   (define/override (get-view fx fy fh fw [full? #f])
+    (define A-VERY-BIG-NUMBER 1e50)
     (cond
      [(not canvas)
       (when fx (set-box! fx 0))
@@ -1230,8 +1231,8 @@
         (and m (send m get-printing)))
       (when fx (set-box! fx 0))
       (when fy (set-box! fy 0))
-      (when fh (set-box! fh 10000))
-      (when fw (set-box! fw 10000))]
+      (when fh (set-box! fh A-VERY-BIG-NUMBER))
+      (when fw (set-box! fw A-VERY-BIG-NUMBER))]
      [else
       (send canvas get-view fx fy fh fw full?)]))
 


### PR DESCRIPTION
Fix for https://github.com/racket/drracket/issues/147

When printing the definitions area in DrRacket, it makes sense to have
the viewable range be essentially infinite, so all of the line numbers
in the file are always printed.  Currently it is hard-coded at a size
of 10000x10000, which turns out to not be high enough.

This patch changes the size to a very large number (1e50), and in my
tests it fixes the linked bug.