### PR TITLE
Add 'new-button style to tab-panel%

### DIFF
--- a/gui-doc/scribblings/gui/tab-panel-class.scrbl
+++ b/gui-doc/scribblings/gui/tab-panel-class.scrbl
@@ -24,8 +24,8 @@ The @racket[tab-panel%] class does not implement the virtual
                             . -> . any) 
                            (lambda (b e) (void))]
                  [style (listof (or/c 'no-border
-                                      'can-reorder 'can-close 'flat-portable
-                                      'deleted))
+                                      'can-reorder 'can-close 'new-button
+				      'flat-portable 'deleted))
                         null]
                  [font (is-a?/c font%) normal-control-font]
                  [enabled any/c #t]
@@ -69,6 +69,11 @@ If the @racket[style] list includes @racket['no-border], no border is
  the @racket['flat-portable] flag is
  effectively always included in @racket[style] on Windows if either
  @racket['can-reorder] or @racket['can-close] is included.
+ If the @racket[style] list includes @racket['new-button] and the
+ platform-independent implementation is used for the tab control,
+ then a new tab button is added to the right of the last tab to allow
+ inserting new tabs. If the new tab button is clicked,
+ @method[tab-panel% on-new-request] is called.
  @DeletedStyleNote[@racket[style] @racket[parent]]{tab panel}
 
 @FontKWs[@racket[font]] @WindowKWs[@racket[enabled]] @SubareaKWs[] @AreaKWs[]
@@ -76,7 +81,8 @@ If the @racket[style] list includes @racket['no-border], no border is
 @history[#:changed "1.55" @elem{Added the @racket['can-reorder] and
                                 @racket['can-close] styles.}
          #:changed "1.56" @elem{Added the @racket['flat-portable] style
-                                with reordering and closing support on Windows.}]}
+                                with reordering and closing support on Windows.}
+         #:changed "1.62" @elem{Added the @racket['new-button] style.}]}
 
 @defmethod[(append [choice label-string?])
            void?]{
@@ -143,6 +149,15 @@ with @racket['no-border]) when creating the panel. The @racket[index]
 argument identifies the tab to potentially close.
 
 @history[#:added "1.55"]}
+
+
+@defmethod[(on-new-request)
+           void?]{
+
+Called when the user clicks the new tab button in a tab panel, which
+is enabled where available by including the @racket['new-button] style.
+
+@history[#:added "1.62"]}
 
 
 @defmethod[(set [choices (listof label-string?)])

--- a/gui-doc/scribblings/gui/tab-panel-class.scrbl
+++ b/gui-doc/scribblings/gui/tab-panel-class.scrbl
@@ -25,7 +25,7 @@ The @racket[tab-panel%] class does not implement the virtual
                            (lambda (b e) (void))]
                  [style (listof (or/c 'no-border
                                       'can-reorder 'can-close 'new-button
-				      'flat-portable 'deleted))
+                                      'flat-portable 'deleted))
                         null]
                  [font (is-a?/c font%) normal-control-font]
                  [enabled any/c #t]

--- a/gui-lib/info.rkt
+++ b/gui-lib/info.rkt
@@ -33,4 +33,4 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.61")
+(define version "1.62")

--- a/gui-lib/mred/private/mrpanel.rkt
+++ b/gui-lib/mred/private/mrpanel.rkt
@@ -204,7 +204,7 @@
                                       '(hscroll vscroll
                                                 auto-hscroll auto-vscroll 
                                                 hide-hscroll hide-vscroll)]
-                                     [(eq? who 'tab-panel) '(can-reorder can-close flat-portable)]
+                                     [(eq? who 'tab-panel) '(can-reorder can-close flat-portable new-button)]
                                      [else null]))
                    style)
 
@@ -367,6 +367,7 @@
                                            normal-control-font
                                            init-font)
                                        (lambda (index) (on-close-request index))
+                                       (lambda () (on-new-request))
                                        (lambda (new-positions) (on-reorder new-positions))
                                        this this
                                        wx
@@ -411,7 +412,7 @@
         (raise-argument-error (who->name cwho) "label-string?" choices))
       (check-callback cwho callback)
       (check-container-parent cwho parent)
-      (check-style cwho #f '(deleted no-border can-reorder can-close flat-portable) style)
+      (check-style cwho #f '(deleted no-border can-reorder can-close flat-portable new-button) style)
       (check-font cwho font))
     (super-new [parent parent]
                [style (if (memq 'no-border style)
@@ -492,7 +493,8 @@
                                                   (set! external-mapping #f)
                                                   (on-reorder new-positions))
                                                 wx:middle-queue-key))]
-     [on-close-request (lambda (which) (void))])
+     [on-close-request (lambda (which) (void))]
+     [on-new-request (lambda () (void))])
     (pubment*
      [on-reorder (lambda (new-positions) (inner (void) on-reorder new-positions))])
 

--- a/gui-lib/mred/private/wxtabcanvas.rkt
+++ b/gui-lib/mred/private/wxtabcanvas.rkt
@@ -168,7 +168,7 @@
     ;; when not #f, scroll-offset should also not be #f
     (define clicked-thumb #f)
 
-    ; (or/c #t #f)
+    ; boolean
     (define clicked-new-button #f)
 
     (define/private (set-clicked-in new-clicked-in new-clicked-in-offset new-clicked-thumb new-clicked-new-button)
@@ -267,6 +267,8 @@
       
       (define new-circle-color
         (cond
+          [clicked-new-button
+           (mouse-down-over-close-circle-color)]
           [mouse-over-new-button?
            (mouse-over-close-circle-color)]
           [else (natural-tab-color)]))
@@ -808,7 +810,9 @@
                     my
                     (+ (/ ch 2) size-of-close-icon-circle))))
          (values tab-candidate-i mx-offset-in-tab (and in-close-x in-close-y) #f #f)]
-        [(and (= tab-candidate-i (number-of-items))
+        [(and (has-new-button?)
+              (not clicked-in)
+              (= tab-candidate-i (number-of-items))
               (>= mx (+ (* tab-candidate-i (width-of-tab))
                         new-button-margin))
               (<= mx (+ (* tab-candidate-i (width-of-tab))

--- a/gui-lib/mred/private/wxtabcanvas.rkt
+++ b/gui-lib/mred/private/wxtabcanvas.rkt
@@ -267,8 +267,10 @@
       
       (define new-circle-color
         (cond
-          [clicked-new-button
+          [(and clicked-new-button mouse-over-new-button?)
            (mouse-down-over-close-circle-color)]
+          [clicked-new-button
+           (selected-tab-color)]
           [mouse-over-new-button?
            (mouse-over-close-circle-color)]
           [else (natural-tab-color)]))
@@ -535,7 +537,7 @@
                               #f
                               mouse-over-thumb
                               mouse-over-new-button?)])
-           (set-mouse-over #f #f #f #f)]
+           (set-mouse-over mouse-over-tab mouse-over-close? mouse-over-thumb mouse-over-new-button?)]
           [(and left-down dragging?)
            ;; maybe this next line needs to refresh only when
            ;; we are dragging a tab, not all the time?
@@ -817,7 +819,11 @@
                         new-button-margin))
               (<= mx (+ (* tab-candidate-i (width-of-tab))
                         new-button-margin
-                        size-of-new-icon-circle)))
+                        size-of-new-icon-circle))
+              ; need to check the height as well for the case where the mouse button was held down
+              ; oven the new button and re-enters the widget
+              (>= my (/ (- ch size-of-new-icon-circle) 2))
+              (<= my (- ch (/ (- ch size-of-new-icon-circle) 2))))
          (values #f #f #f #f #t)]
         [else
          (values #f #f #f #f #f)]))

--- a/gui-lib/mred/private/wxtabcanvas.rkt
+++ b/gui-lib/mred/private/wxtabcanvas.rkt
@@ -258,7 +258,7 @@
 
     (define/private (draw-new-button i x-start)
       (define dc (get-dc))
-      (define new-icon-start (+ x-start horizontal-item-margin))
+      (define new-icon-start (+ x-start new-button-margin))
       (define-values (cw ch) (get-client-size))
       (define cx (+ new-icon-start (/ size-of-new-icon-circle 2)))
       (define cy (/ ch 2))
@@ -717,9 +717,9 @@
         [(? number? n) n]))
     (define (new-button-width)
       (if (has-new-button?)
-          (+ horizontal-item-margin
+          (+ new-button-margin
              size-of-new-icon-circle
-             horizontal-item-margin)
+             new-button-margin)
           0))
     (define/private (compute-width-of-tab)
       (define-values (cw ch) (get-client-size))
@@ -808,9 +808,9 @@
          (values tab-candidate-i mx-offset-in-tab (and in-close-x in-close-y) #f #f)]
         [(and (= tab-candidate-i (number-of-items))
               (>= mx (+ (* tab-candidate-i (width-of-tab))
-                        horizontal-item-margin))
+                        new-button-margin))
               (<= mx (+ (* tab-candidate-i (width-of-tab))
-                        horizontal-item-margin
+                        new-button-margin
                         size-of-new-icon-circle)))
          (values #f #f #f #f #t)]
         [else
@@ -837,6 +837,7 @@
 (define horizontal-item-margin 10)
 (define top-item-margin 5)
 (define bottom-item-margin 3)
+(define new-button-margin (/ horizontal-item-margin 2))
 
 (define end-of-label-horizontal-gradient-amount 16)
 

--- a/gui-lib/mred/private/wxtabcanvas.rkt
+++ b/gui-lib/mred/private/wxtabcanvas.rkt
@@ -239,9 +239,9 @@
 
       (when (has-new-button?)
         (define sp (natural-left-position (number-of-items)))
-          (unless (< (+ sp tw) 0) ;; entirely to the left of being visible
-            (unless (< cw sp)     ;; entirely to the right of being visible
-              (draw-new-button (number-of-items) sp))))
+        (unless (< (+ sp tw) 0) ;; entirely to the left of being visible
+          (unless (< cw sp)     ;; entirely to the right of being visible
+            (draw-new-button (number-of-items) sp))))
 
       ;; 2.
       (draw-lines-between-items)
@@ -735,8 +735,10 @@
 
     (define/private (white-on-black-panel-scheme?) #f)
 
+    ;; also include the size of the new button if present
     (define/private (min-size-of-all-tabs-together)
-      (* (number-of-items) (get-min-tab-width)))
+      (+ (* (number-of-items) (get-min-tab-width))
+         (new-button-width)))
 
     (define/private (scroll-offset-rightmost)
       (define-values (cw ch) (get-client-size))


### PR DESCRIPTION
The 'new-button style adds a '+' button to the right of the last tab in the panel to support inserting new tabs to the panel. This implementation is for the platform-independent wxtabcanvas only.

My app which uses this code is here: https://github.com/jjsimpso/molasses/tree/tab-panel-experiment
