### PR TITLE
cocoa: allow duplicate choice% labels

### DIFF
--- a/gui-lib/mred/private/wx/cocoa/choice.rkt
+++ b/gui-lib/mred/private/wx/cocoa/choice.rkt
@@ -30,18 +30,21 @@
   (inherit get-cocoa init-font register-as-child)
 
   (super-new [parent parent]
-             [cocoa 
-              (let ([cocoa 
+             [cocoa
+              (let ([cocoa
                      (as-objc-allocation
-                      (tell (tell RacketPopUpButton alloc) 
+                      (tell (tell RacketPopUpButton alloc)
                             initWithFrame: #:type _NSRect (make-NSRect (make-init-point x y)
                                                                        (make-NSSize w h))
                             pullsDown: #:type _BOOL #f))])
+                (define menu (tell cocoa menu))
                 (for ([lbl (in-list choices)]
                       [i (in-naturals)])
-                  (tellv cocoa 
-                         insertItemWithTitle: #:type _NSString lbl 
-                         atIndex: #:type _NSInteger i))
+                  (tell menu
+                        insertItemWithTitle: #:type _NSString lbl
+                        action: #:type _SEL #f
+                        keyEquivalent: #:type _NSString ""
+                        atIndex: #:type _NSInteger i))
                 (init-font cocoa font)
                 (tellv cocoa sizeToFit)
                 (tellv cocoa setTarget: cocoa)
@@ -65,9 +68,12 @@
   (define/public (clear)
     (tellv (get-cocoa) removeAllItems))
   (define/public (append lbl)
-    (tellv (get-cocoa)
-           insertItemWithTitle: #:type _NSString lbl 
-           atIndex: #:type _NSInteger (number)))
+    (define menu (tell (get-cocoa) menu))
+    (tell menu
+          insertItemWithTitle: #:type _NSString lbl
+          action: #:type _SEL #f
+          keyEquivalent: #:type _NSString ""
+          atIndex: #:type _NSInteger (number)))
   (define/public (delete i)
     (tellv (get-cocoa) removeItemAtIndex: #:type _NSInteger i))
 


### PR DESCRIPTION
`NSPopUpButton` checks for duplicates before inserting new items, which
means code like

    (new choice% [choices '("a" "a" "b")] ...)

would previously panic with

    "Invalid parameter not satisfying: index <= [_item Array count]"

because the implementation would attempt to insert the "b"
label at position 2, thinking two "a" labels were inserted when only
one was.

This change uses the underlying NSMenu methods to append items since
they don't check for duplicates.  In addition to fixing the crash, it
brings the implementation in line with the one on Linux, where
duplicates are allowed.  I assume the Windows implementation also
allows duplicates, but I haven't tried it.