### PR TITLE
wxtabcanvas: fix painting with no items

### DIFF
--- a/gui-lib/mred/private/wxtabcanvas.rkt
+++ b/gui-lib/mred/private/wxtabcanvas.rkt
@@ -726,10 +726,14 @@
              new-button-margin)
           0))
     (define/private (compute-width-of-tab)
-      (define-values (cw ch) (get-client-size))
+      (define-values (cw _ch) (get-client-size))
       (define dc (get-dc))
-      (define shrinking-required-size (- (/ cw (number-of-items))
-                                         (/ (new-button-width) (number-of-items))))
+      (define n-items (number-of-items))
+      (define shrinking-required-size
+        (if (zero? n-items)
+            (- cw (new-button-width))
+            (- (/ cw n-items)
+               (/ (new-button-width) n-items))))
 
       ;; this is the maximum size that a tab will ever be
       (define unconstrained-tab-size (* (send (send dc get-font) get-point-size) 12))


### PR DESCRIPTION
This fixes a division by zero error when the `flat-portable` style is used with no tabs (which the contract for `tab-panel%` allows and works with at least the native style on macOS).

Failing example:

```racket
#lang racket/gui

(define f (new frame%
               [label "Test"]))
(define t (new (class tab-panel%
                 (super-new)
                 (define/override (on-new-request)
                   (send this set '("a"))))
               [parent f]
               [choices '()]
               [style '(no-border flat-portable new-button)]))
(send f show #t)
```
