### PR TITLE
Add grapheme support to the editor classes

### DIFF
--- a/gui-doc/scribblings/gui/editor-overview.scrbl
+++ b/gui-doc/scribblings/gui/editor-overview.scrbl
@@ -225,6 +225,40 @@ When an editor is drawn into a display, each snip and position has a
  editor. Locations in an editor are only meaningful when the editor is
  displayed.
 
+@subsection[#:tag "graphemes"]{Characters, Graphemes, and Source Locations}
+
+For historical reasons, an @tech{item} corresponds to a Racket
+ character in an editor with text. Some things that a user would
+ perceive as a character are composed of multiple Racket characters,
+ however, such as a pirate-flag emoji (which uses a four-character
+ encoding) or ``e'' plus an accent modifier (which also has a single
+ character representation, but might be represented through those two
+ characters). A @deftech{grapheme} is an approximation to a
+ user-perceived character as defined by the Unicode grapheme-cluster
+ specification.
+
+Racket provides support for graphemes though functions like
+ @racket[string-grapheme-count] and @racket[char-grapheme-step].
+ Source locations are intended to be count by graphemes instead of
+ characters, and to support such source locations, port line and
+ position counting as enabled by @racket[port-count-lines!] tracks
+ graphemes.
+
+Working with graphemes in a text editor requires extra care. Methods
+ like @xmethod[text% grapheme-position] and @xmethod[text%
+ position-grapheme] convert between item and grapheme indices, but
+ most operations are based in item positions, and they are generally
+ not constrained to preserve grapheme-cluster sequences. A grapheme
+ cluster that is within a single snip will render as a single
+ grapheme, but a grapheme cluster that spans a snip boundary will be
+ rendered as two partial graphemes. The @xmethod[text% insert] method
+ takes optional arguments to trigger the detection of grapheme
+ sequences that would span the existing and inserted content and
+ ensure that the sequences are kept together.
+
+A small number of @racket[text%] methods are grapheme-sensitive by
+ default: @method[text% delete], @method[text% insert] of a character,
+ and @method[text% move-position].
 
 @subsection[#:tag "editoradministrators"]{Administrators}
 

--- a/gui-doc/scribblings/gui/snip-class.scrbl
+++ b/gui-doc/scribblings/gui/snip-class.scrbl
@@ -206,12 +206,35 @@ Returns the administrator for this snip. (The administrator can be
 }
 
 @defmethod[(get-count)
-           (integer-in 0 100000)]{
+           exact-nonnegative-integer?]{
 
 Returns the snip's @techlink{count} (i.e., number of @techlink{item}s
  within the snip).
 
 }
+
+@defmethod[(get-grapheme-count)
+           exact-nonnegative-integer?]{
+
+Returns the number of @techlink{graphemes} in the snip, which is
+usually the same result as @method[snip<%> get-count], but can be
+smaller with multiple consecutive @tech{items} form a grapheme.
+
+@history[#:added "1.67"]}
+
+
+@defmethod[(grapheme-position [n exact-nonnegative-integer?])
+           exact-nonnegative-integer?]{
+
+Returns the number of @tech{items} in the snip that form the first
+@racket[n] @tech{graphemes}; or, equivalently, converts from an
+@tech{grapheme}-based position to a @tech{item}-based position.
+
+When @method[snip<%> get-count] is the same as @method[snip<%>
+get-grapheme-count], this method returns @racket[n].
+
+@history[#:added "1.67"]}
+
 
 @defmethod[(get-extent [dc (is-a?/c dc<%>)]
                        [x real?]
@@ -617,6 +640,19 @@ The @racket[own-it?] argument is @racket[#t] if the snip owns the
 Does nothing.
 
 }}
+
+
+@defmethod[(position-grapheme [n exact-nonnegative-integer?])
+           exact-nonnegative-integer?]{
+
+Returns the number of @tech{graphemes} within the snip formed by the
+first @racket[n] @tech{items}; or, equivalently, converts from an
+@tech{item}-based position to a @tech{grapheme}-based position.
+
+When @method[snip<%> get-count] is the same as @method[snip<%>
+get-grapheme-count], this method returns @racket[n].
+
+@history[#:added "1.67"]}
 
 
 @defmethod[(partial-offset [dc (is-a?/c dc<%>)]

--- a/gui-lib/framework/private/color.rkt
+++ b/gui-lib/framework/private/color.rkt
@@ -306,7 +306,8 @@ added get-regions
     (inherit change-style begin-edit-sequence end-edit-sequence highlight-range
              get-style-list in-edit-sequence? get-start-position get-end-position
              local-edit-sequence? get-styles-fixed has-focus?
-             get-fixed-style get-text)
+             get-fixed-style get-text
+             position-grapheme grapheme-position)
     
     (define lexers-all-valid? #t)
     (define/private (update-lexer-state-observers)
@@ -386,10 +387,16 @@ added get-regions
                 [(defer) ((+ start-time 20.0) . <= . (current-inexact-milliseconds))]))
          #f]
         [else
+         (define in-start-grapheme (position-grapheme in-start-pos))
          (define-values (_line1 _col1 pos-before) (port-next-location in))
-         (define-values (lexeme attribs paren new-token-start new-token-end
+         (define-values (lexeme attribs paren new-token-start-grapheme new-token-end-grapheme
                                 backup-delta new-lexer-mode/cont)
-           (get-token in in-start-pos lexer-mode))
+           (get-token in in-start-grapheme lexer-mode))
+         ;; port counting is in 1-based graphemes, while but we want 1-based positions after here
+         (define new-token-start (and new-token-start-grapheme
+                                      (+ 1 (- (grapheme-position (+ in-start-grapheme new-token-start-grapheme -1)) in-start-pos))))
+         (define new-token-end (and new-token-end-grapheme
+                                    (+ 1 (- (grapheme-position (+ in-start-grapheme new-token-end-grapheme -1)) in-start-pos))))
          (define-values (_line2 _col2 pos-after) (port-next-location in))
          (define new-lexer-mode (if (dont-stop? new-lexer-mode/cont)
                                     (dont-stop-val new-lexer-mode/cont)
@@ -397,7 +404,7 @@ added get-regions
          (define next-ok-to-stop? (not (dont-stop? new-lexer-mode/cont)))
          (check-colorer-results-match-port-before-and-after
           'color:text<%>
-          (attribs->type attribs) pos-before new-token-start new-token-end pos-after)
+          (attribs->type attribs) pos-before new-token-start-grapheme new-token-end-grapheme pos-after)
          (cond
            [(eq? 'eof attribs) 
             (set-lexer-state-up-to-date?! ls #t)

--- a/gui-lib/info.rkt
+++ b/gui-lib/info.rkt
@@ -34,7 +34,7 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.66")
+(define version "1.67")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/gui-lib/mred/private/wxme/text.rkt
+++ b/gui-lib/mred/private/wxme/text.rkt
@@ -24,7 +24,8 @@
          "wordbreak.rkt"
          "stream.rkt"
          "wx.rkt"
-         racket/draw/private/region)
+         racket/draw/private/region
+         racket/snip/private/grapheme)
 
 (provide text%
          add-text-keymap-functions
@@ -1105,7 +1106,9 @@
                                  start)]
                               [(eq? 'line kind)
                                (line-start-position (position-line start posateol?))]
-                              [else (max 0 (sub1 start))]))])
+                              [else
+                               (grapheme-position
+                                (max 0 (sub1 (position-grapheme start))))]))])
                       (let-values ([(start end)
                                     (if extend?
                                         (if leftshrink?
@@ -1133,7 +1136,9 @@
                                  end)]
                               [(eq? 'line kind)
                                (line-end-position (position-line end posateol?))]
-                              [else (add1 end)]))])
+                              [else
+                               (grapheme-position
+                                (add1 (position-grapheme end)))]))])
                       (let-values ([(start end)
                                     (if extend?
                                         (if rightshrink?
@@ -1849,19 +1854,34 @@
      [([string? str] 
        [exact-nonnegative-integer? start] 
        [(make-alts exact-nonnegative-integer? (symbol-in same)) [end 'same]]
-       [any? [scroll-ok? #t]])
-      (do-insert #f str #f start end scroll-ok?)]
+       [any? [scroll-ok? #t]]
+       [any? [join-graphemes? #f]])
+      (if join-graphemes?
+          (do-insert-graphemes str start end scroll-ok?)
+          (do-insert #f str #f start end scroll-ok?))]
      [([exact-nonnegative-integer? len] 
-       [string? str])
+       [string? str]
+       [any? [join-graphemes? #f]])
       (check-len str len)
-      (do-insert #f (substring str 0 len) #f startpos endpos #t)]
+      (let ([str (if (= len (string-length str))
+                     str
+                     (substring str 0 len))])
+        (if join-graphemes?
+            (do-insert-graphemes str startpos endpos #t)
+            (do-insert #f str #f startpos endpos #t)))]
      [([exact-nonnegative-integer? len] 
        [string? str] 
        [exact-nonnegative-integer? start] 
        [(make-alts exact-nonnegative-integer? (symbol-in same)) [end 'same]]
-       [any? [scroll-ok? #t]])
+       [any? [scroll-ok? #t]]
+       [any? [join-graphemes? #f]])
       (check-len str len)
-      (do-insert #f (substring str 0 len) #f start end scroll-ok?)]
+      (let ([str (if (= len (string-length str))
+                     str
+                     (substring str 0 len))])
+        (if join-graphemes?
+            (do-insert-graphemes str startpos endpos #t)
+            (do-insert #f str #f start end scroll-ok?)))]
      [([snip% snip])
       (do-insert snip #f #f startpos endpos #t)]
      [([snip% snip]
@@ -1885,9 +1905,46 @@
           [ifs? insert-force-streak?])
       (end-streaks '(delayed))
       (set! insert-force-streak? streak?)
-      (do-insert #f (string ch) #f start end #t)
+
+      (cond
+        [(char-iso-control? ch)
+         ;; shortcut for character that never joins, especially #\newline
+         (do-insert #f (string ch) #f start end #t)]
+        [else
+         (do-insert-graphemes (string ch) start end #t)])
+
       (set! insert-force-streak? ifs?)
       (set! typing-streak? #t)))
+
+  (define/private (do-insert-graphemes str start end scroll-ok?)
+    ;; maybe join characters to form a grapheme; we limit
+    ;; the search for a grapheme to one surrounding snip on
+    ;; the grounds that this makes sense when graphemes are
+    ;; already joined
+    (let loop ([s str] [start start] [end end])
+      (define pre-s (do-find-snip start 'before))
+      (define pre-pos (get-snip-position pre-s))
+      (define pre-count (snip->count pre-s))
+      (define txt (send pre-s get-text 0 (- start pre-pos)))
+      (cond
+        [(grapheme-spans? txt 0 (- start pre-pos)
+                          s 0 (string-length s))
+         (loop (string-append (string (string-ref txt (- start pre-pos 1))) s)
+               (sub1 start)
+               end)]
+        [else
+         (define post-s (do-find-snip end 'after))
+         (define post-pos (get-snip-position post-s))
+         (define post-count (snip->count post-s))
+         (define txt (send post-s get-text 0 post-count))
+         (cond
+           [(grapheme-spans? s 0 (string-length s)
+                             txt (- end post-pos) post-count)
+            (loop (string-append s (string (string-ref txt (- end post-pos))))
+                  start
+                  (add1 end))]
+           [else
+            (do-insert #f s #f start end #t)])])))
 
   (define/private (do-delete start end with-undo? [scroll-ok? #t])
     (assert (consistent-snip-lines 'do-delete))
@@ -1896,7 +1953,10 @@
                     (if (eq? end 'back)
                         (if (zero? start)
                             (values 0 0 #f)
-                            (values (sub1 start) start #t))
+                            (values (grapheme-position
+                                     (sub1 (position-grapheme start)))
+                                    start
+                                    #t))
                         (values start end (and (= start startpos)
                                                (= end endpos))))])
         (end-streaks '(delayed))
@@ -2776,9 +2836,10 @@
                               [s2 (if (equal? #\return (string-ref s1 (sub1 len)))
                                       (substring s1 0 (sub1 len))
                                       s1)])
-                         (insert (regexp-replace* #rx"\r\n" 
-                                                  (if saved-cr? (string-append "\r" s2) s2)
-                                                  "\n"))
+                         (let ([str (regexp-replace* #rx"\r\n" 
+                                                     (if saved-cr? (string-append "\r" s2) s2)
+                                                     "\n")])
+                           (insert (string-length str) str #t))
                          (loop (not (eq? s1 s2))))))))
                #f])])
         
@@ -3083,26 +3144,27 @@
                              (- x))))
              0]
             [else
-              ;; binary search for position within snip:
-              (let loop ([range c]
-                         [i (quotient c 2)]
-                         [offset 0])
-                (let ([dl (send snip partial-offset dc X Y (+ offset i))])
-                  (if (dl . > . x)
-                      (loop i (quotient i 2) offset)
-                      (let ([dr (send snip partial-offset dc X Y (+ offset i 1))])
-                        (if (dr . <= . x)
-                            (let ([range (- range i)])
-                              (loop range (quotient range 2) (+ offset i)))
-                            (begin
-                              (when how-close
-                                (set-box! how-close
-                                          (if ((- dr x) . < . (- x dl))
-                                              (- dr x)
-                                              (- dl x))))
-                              (set! write-locked? wl?)
-                              (set! flow-locked? fl?)
-                              (+ i offset)))))))])))]))
+             ;; binary search for grapheme position within snip, returning character position:
+             (let ([c (snip->grapheme-count snip)])
+               (let loop ([range c]
+                          [i (quotient c 2)]
+                          [offset 0])
+                 (let ([dl (send snip partial-offset dc X Y (send snip grapheme-position (+ offset i)))])
+                   (if (dl . > . x)
+                       (loop i (quotient i 2) offset)
+                       (let ([dr (send snip partial-offset dc X Y (send snip grapheme-position (+ offset i 1)))])
+                         (if (dr . <= . x)
+                             (let ([range (- range i)])
+                               (loop range (quotient range 2) (+ offset i)))
+                             (begin
+                               (when how-close
+                                 (set-box! how-close
+                                           (if ((- dr x) . < . (- x dl))
+                                               (- dr x)
+                                               (- dl x))))
+                               (set! write-locked? wl?)
+                               (set! flow-locked? fl?)
+                               (send snip grapheme-position (+ i offset)))))))))])))]))
 
   (def/public (find-line [real? y] [maybe-box? [onit? #f]])
     (when onit?
@@ -3160,6 +3222,30 @@
                        (mline-prev line)
                        line)])
         (mline-get-line line))]))
+
+  (def/public (position-grapheme [exact-nonnegative-integer? start]
+                                 [any? [eog? #f]])
+    (cond
+     [(not (check-recalc (max-width . > . 0) #f #t)) 0]
+     [(start . <= . 0) 0]
+     [(start . >= . len)
+      (+ (mline-get-grapheme-position last-line)
+         (mline-grapheme-len last-line))]
+     [else
+      (let* ([line (mline-find-position (unbox line-root-box) start)])
+        (let loop ([pos (mline-get-position line)]
+                   [grapheme-pos (mline-get-grapheme-position line)]
+                   [snip (mline-snip line)])
+          (cond
+            [(= pos start) grapheme-pos]
+            [(not snip) grapheme-pos]
+            [else
+             (define c (snip->count snip))
+             (cond
+               [(>= start (+ pos c))
+                (loop (+ pos c) (+ grapheme-pos (snip->grapheme-count snip)) (snip->next snip))]
+               [else
+                (+ grapheme-pos (send snip position-grapheme (- start pos)))])])))]))
 
   
   (def/public-final (get-snip-position-and-location [snip% thesnip] [maybe-box? pos] 
@@ -3407,6 +3493,29 @@
                                  [any? [visible-only? #t]])
     (do-line-position #f i visible-only?))
 
+  (def/public (grapheme-position [exact-nonnegative-integer? start]
+                                 [any? [eog? #f]])
+    (cond
+     [(not (check-recalc (max-width . > . 0) #f #t)) 0]
+     [(start . <= . 0) 0]
+     [(start . >= . (+ (mline-get-grapheme-position last-line)
+                       (mline-grapheme-len last-line)))
+      len]
+     [else
+      (let* ([line (mline-find-grapheme-position (unbox line-root-box) start)])
+        (let loop ([pos (mline-get-position line)]
+                   [grapheme-pos (mline-get-grapheme-position line)]
+                   [snip (mline-snip line)])
+          (cond
+            [(= grapheme-pos start) pos]
+            [(not snip) pos]
+            [else
+             (define c (snip->grapheme-count snip))
+             (cond
+               [(>= start (+ grapheme-pos c))
+                (loop (+ pos (snip->count snip)) (+ grapheme-pos c) (snip->next snip))]
+               [else
+                (+ pos (send snip grapheme-position (- start grapheme-pos)))])])))]))
 
   (def/public (line-length [exact-nonnegative-integer? i])
     (cond

--- a/gui-test/tests/gracket/wxme.rkt
+++ b/gui-test/tests/gracket/wxme.rkt
@@ -68,10 +68,12 @@
 (expect (mline-get-line m20) 1)
 (expect (mline-get-position m00) 0)
 (expect (mline-get-position m20) 0)
-(void (mline-set-length m00 5))
-(void (mline-set-length m20 20))
+(void (mline-set-length m00 5 4))
+(void (mline-set-length m20 20 8))
 (expect (mline-get-position m00) 0)
 (expect (mline-get-position m20) 5)
+(expect (mline-get-grapheme-position m20) 4)
+(expect (mline-grapheme-len m20) 8)
 
 (mline-check-consistent (unbox root-box))
 
@@ -81,21 +83,24 @@
 (define m5 (mline-insert m20 root-box #t))
 (mline-check-consistent (unbox root-box))
 
-(void (mline-set-length m5 10))
+(void (mline-set-length m5 10 8))
 
 (expect (mline-get-position m00) 0)
 (expect (mline-get-position m5) 5)
 (expect (mline-get-position m20) 15)
+(expect (mline-get-grapheme-position m20) 12)
 
 (mline-delete m5 root-box)
 (expect (mline-get-position m20) 5)
+(expect (mline-get-grapheme-position m20) 4)
 
 (set! m5 (mline-insert m20 root-box #t))
-(void (mline-set-length m5 8))
+(void (mline-set-length m5 8 7))
 
 (expect (mline-get-position m00) 0)
 (expect (mline-get-position m5) 5)
 (expect (mline-get-position m20) 13)
+(expect (mline-get-grapheme-position m20) 11)
 
 (mline-delete m5 root-box)
 
@@ -121,7 +126,7 @@
 
 (define m05 (mline-insert m00 root-box #f))
 
-(void (mline-set-length m05 2))
+(void (mline-set-length m05 2 2))
 
 (expect (mline-get-line m00) 0)
 (expect (mline-get-line m05) 1)
@@ -609,6 +614,37 @@
             (fast-string-search thing-to-search-for text-to-search-in)
             #:extra-stuff (list thing-to-search-for thing-to-search-in))))
 
+;; ----------------------------------------
+;; Graphemes
+
+(let ()
+  (define t (new text%))
+  (send t insert "he\u300llo")
+  (expect (send t position-grapheme 5) 4)
+  (expect (send t grapheme-position 5) 6)
+  (send t insert "a" 1)
+  (expect (send t position-grapheme 0) 0)
+  (expect (send t position-grapheme 1) 1)
+  (expect (send t position-grapheme 2) 2)
+  (expect (send t position-grapheme 5) 4)
+  (expect (send t grapheme-position 5) 6)
+  (expect (send t last-position) 7)
+  (send t set-position 4)
+  (send t delete)
+  (expect (send t last-position) 5)
+  (send t insert "e\u300")
+  (expect (send t last-position) 7)
+  (expect (send t grapheme-position 6) 7)
+  (expect (send t position-grapheme 2) 2)
+  (expect (send t position-grapheme 3) 2)
+  (expect (send t position-grapheme 4) 3)
+  (expect (send t position-grapheme 7) 6)
+  (send t insert "\n" 1)
+  (expect (send t last-position) 8)
+  (expect (send t position-grapheme 8) 7)
+  (expect (send t position-grapheme 3) 3)
+  (expect (send t position-grapheme 5) 4))
+  
 ;; ----------------------------------------
 
 ;; Insert very long strings to test max-string-length handling


### PR DESCRIPTION
Builds on racket/racket#4350, racket/draw#49, and racket/snip#9.

Changing `text%` so that positions correspond to glyphs is the obvious choice, but that change appears to be unworkable. There are too many things in the current API and uses that make sense only when position delta = character count. In the approach here, graphing counting is added separately, alongside line counting and graphical-size counting.

The `snip%` class gets three new methods: `get-grapheme-count`, `grapheme-position` (converts from graphemes to characters), and`position-grapheme` (covert from characters to graphemes). The default implementares the same as `get-count` and identity functions, respectively, but they're specialized for `string-snip%`.
    
The `text%` class also gets `grapheme-position` and `position-grapheme`, plus some grapheme sensitively (automatic for characters, on demand for strings) in `insert` and (automatic) in `move-position`, `delete`, and `on-default-char`. For compatibility, however, items and positions still corerspond to characters.

External extensions of an editor, such as keybindings would need to be adjusted to work right, but that can be done incrementally. Meanwhile, they won’t be any more broken from a user's perspective than now.