### PR TITLE
refreshing canvases when entering/leaving dark mode

### DIFF
--- a/gui-lib/mred/private/wx/cocoa/frame.rkt
+++ b/gui-lib/mred/private/wx/cocoa/frame.rkt
@@ -48,6 +48,18 @@
 ;;  problems.
 (define all-windows (make-hash))
 
+(set-queue-events-to-refresh-all-canvases!
+ (let ([queue-events-to-refresh-all-canvases
+        (λ ()
+          (atomically
+           (for ([b (in-hash-values all-windows)])
+             (define frame (weak-box-value b))
+             (when frame
+               (queue-event
+                (send frame get-eventspace)
+                (λ () (send frame request-refresh-all-canvas-children)))))))])
+   queue-events-to-refresh-all-canvases))
+
 ;; called in atomic mode
 (define (send-screen-change-notifications flags)
   (reset-menu-bar!)

--- a/gui-lib/mred/private/wx/cocoa/queue.rkt
+++ b/gui-lib/mred/private/wx/cocoa/queue.rkt
@@ -30,7 +30,8 @@
               try-to-sync-refresh
               try-to-flush
               sync-cocoa-events
-              set-screen-changed-callback!)
+              set-screen-changed-callback!
+              set-queue-events-to-refresh-all-canvases!)
 
  ;; from common/queue:
  current-eventspace
@@ -102,6 +103,7 @@
       ;; we add an observer only for "effectiveAppearance",
       ;; so no check is needed to know why we got here
       (queue-dark-mode-event)
+      (queue-events-to-refresh-all-canvases)
       (void)]
   [-a _BOOL (applicationShouldHandleReopen: [_id app] hasVisibleWindows: [_BOOL has-visible?])
       ;; If we have any visible windows, return #t to do the default thing.
@@ -120,6 +122,10 @@
       (try-dock-to-front)]
   [-a _void (retrySelfToFront: o)
       (tellv app activateIgnoringOtherApps: #:type _BOOL #t)])
+
+(define queue-events-to-refresh-all-canvases void)
+(define (set-queue-events-to-refresh-all-canvases! f)
+  (set! queue-events-to-refresh-all-canvases f))
 
 (define fixup-window-locations void)
 (define (set-fixup-window-locations! f) (set! fixup-window-locations f))

--- a/gui-lib/mred/private/wxpanel.rkt
+++ b/gui-lib/mred/private/wxpanel.rkt
@@ -7,6 +7,7 @@
            "helper.rkt"
            "check.rkt"
            "wx.rkt"
+           "wxcanvas.rkt"
            "wxwindow.rkt"
            "wxitem.rkt"
            "wxcontainer.rkt")
@@ -328,7 +329,17 @@
                              (child-info-x-min (car kid-info)))))
            (lambda (y-accum kid-info first?)
              (max y-accum (+ (* 2 (border))
-                             (child-info-y-min (car kid-info)))))))])
+                             (child-info-y-min (car kid-info)))))))]
+
+       ;; request that all children that are canvases refresh their content
+       [request-refresh-all-canvas-children
+        (λ ()
+          (for ([child (in-list children)])
+            (cond
+              [(is-a? child wx-basic-panel<%>)
+               (send child request-refresh-all-canvas-children)]
+              [(is-a? child wx-canvas%)
+               (send child queue-paint)])))])
 	       
       (override*
        [force-redraw

--- a/gui-lib/mred/private/wxtop.rkt
+++ b/gui-lib/mred/private/wxtop.rkt
@@ -289,6 +289,11 @@
 	       
               (set! pending-redraws? #f)))]
 
+       [request-refresh-all-canvas-children
+        (λ ()
+          (when panel
+            (send panel request-refresh-all-canvas-children)))]
+
        [correct-size
         (lambda (frame-w frame-h)
           (if (not panel)


### PR DESCRIPTION
There is at least one problem with this pr, namely that it only requests refreshes for the frames in the original/main eventspace. I had thought of using the custodian hierarchy to reach other eventspaces but this doesn't work because I need a parent custodian that I don't have.

I'm also not sure if `queue-paint` is the right method to invoke when finding a canvas.