### PR TITLE
adjust the byte conversion loop in open-output-text-editor to pull ou…

### DIFF
--- a/gui-lib/mred/private/snipfile.rkt
+++ b/gui-lib/mred/private/snipfile.rkt
@@ -354,7 +354,7 @@
       (define (show s)
         (define (insert)
           (send text begin-edit-sequence)
-          (send text insert s pos)
+          (send text insert s pos 'same #t #t)
           (send text end-edit-sequence))
         (if (and eventspace
                  (and (not (eq? (current-thread) 

--- a/gui-lib/mred/private/snipfile.rkt
+++ b/gui-lib/mred/private/snipfile.rkt
@@ -364,12 +364,12 @@
             (insert))
 	(set! pos (+ (string-length s) pos)))
       (define (flush-text)
-	(let ([cnt (peek-bytes-avail!* raw-buffer 0 #f in)])
+	(let ([cnt (peek-bytes-avail!** raw-buffer 0 #f in)])
 	  (when (positive? cnt)
 	    (let-values ([(got used status) (bytes-convert cvt raw-buffer 0 cnt utf8-buffer)])
 	      (cond
 	       [(positive? got) 
-		(read-bytes-avail!* raw-buffer in 0 used)
+                (read-bytes! raw-buffer in 0 used)
 		(show (bytes->string/utf-8 utf8-buffer #\? 0 got))
 		(flush-text)]
 	       [(eq? status 'error) 
@@ -412,4 +412,11 @@
 		     (add1 pos))))
 	 void
 	 (add1 pos)))
-      port)))
+      port))
+
+  (define (peek-bytes-avail!** bstr skip progress-evt in)
+    (let loop ([got 0])
+      (define cnt (peek-bytes-avail!* bstr (+ skip got) progress-evt in got))
+      (if (zero? cnt)
+          got
+          (loop (+ got cnt))))))

--- a/gui-lib/mred/private/wxme/text.rkt
+++ b/gui-lib/mred/private/wxme/text.rkt
@@ -1923,14 +1923,16 @@
       (set! insert-force-streak? ifs?)
       (set! typing-streak? #t)))
 
-  (define/private (do-insert-graphemes str start end scroll-ok?)
+  (define/private (do-insert-graphemes str start-in end-in scroll-ok?)
     ;; maybe join characters to form a grapheme; we limit
     ;; the search for a grapheme to one surrounding snip on
     ;; the grounds that this makes sense when graphemes are
     ;; already joined
+    (define start (max 0 (min start-in len)))
+    (define end (if (eq? end-in 'same) start (max start (min end-in len))))
     (define keep-caret? (and (= start startpos)
                              (or (eq? end 'same) (eqv? end start))))
-    (let loop ([s str] [start start] [end (if (eq? end 'same) start (max start end))])
+    (let loop ([s str] [start start] [end end])
       (define pre-s (do-find-snip start 'before))
       (define pre-pos (get-snip-position pre-s))
       (define pre-count (snip->count pre-s))

--- a/gui-test/tests/gracket/editor.rktl
+++ b/gui-test/tests/gracket/editor.rktl
@@ -394,6 +394,26 @@
   (close-output-port p)
   (test "a· ·" 'unicode-code-point-broken-up (send t get-text)))
 
+(let ()
+  (define t (new text%))
+  (send t set-styles-sticky #f)
+  (define bts #"\360\237\217\264\342\200\215\342\230\240\357\270\217")
+  (define p (open-output-text-editor t))
+  (write-bytes bts p)
+  (close-output-port p)
+  (test 1 'pirate-flag-all-at-once (send t last-position)))
+
+(let ()
+  (define t (new text%))
+  (define bts #"\360\237\217\264\342\200\215\342\230\240\357\270\217")
+  (define p (open-output-text-editor t))
+  (for ([b (in-bytes bts)])
+    (write-byte b p)
+    (flush-output p))
+  (close-output-port p)
+  (test 1 'pirate-flag-piece-by-piece (send t last-position)))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                            Snips and Streams                               ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/gui-test/tests/gracket/editor.rktl
+++ b/gui-test/tests/gracket/editor.rktl
@@ -413,6 +413,22 @@
   (close-output-port p)
   (test 1 'pirate-flag-piece-by-piece (send t position-grapheme (send t last-position))))
 
+(let ()
+  (define bts '(#"\360\237\217\264" #"\342\200\215" #"\342\230\240" #"\357\270\217"))
+  (define txt (new text%))
+  (send txt set-styles-sticky #f)
+  (send txt insert "az")
+  (for ([b (in-list bts)]
+        [i (in-naturals)])
+    (define p (open-output-text-editor txt (- (send txt last-position) 1)))
+    (write-bytes b p)
+    (close-output-port p)
+    (when (= i 0)
+      (send txt change-style (make-object style-delta% 'change-bold) 1 2)))
+  (test '(0 1 5 6)
+        'pirate-flag-char-by-char
+        (for/list ([i (in-list '(0 1 2 3))])
+          (send txt grapheme-position i))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                            Snips and Streams                               ;;

--- a/gui-test/tests/gracket/editor.rktl
+++ b/gui-test/tests/gracket/editor.rktl
@@ -401,7 +401,7 @@
   (define p (open-output-text-editor t))
   (write-bytes bts p)
   (close-output-port p)
-  (test 1 'pirate-flag-all-at-once (send t last-position)))
+  (test 1 'pirate-flag-all-at-once (send t position-grapheme (send t last-position))))
 
 (let ()
   (define t (new text%))
@@ -411,7 +411,7 @@
     (write-byte b p)
     (flush-output p))
   (close-output-port p)
-  (test 1 'pirate-flag-piece-by-piece (send t last-position)))
+  (test 1 'pirate-flag-piece-by-piece (send t position-grapheme (send t last-position))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/gui-test/tests/gracket/editor.rktl
+++ b/gui-test/tests/gracket/editor.rktl
@@ -376,6 +376,24 @@
   (test #\a    'snips-joined4 char1)
   (test "bcd" 'snips-joined5 chars))
 
+(let ()
+  (define t (new text%))
+  (define p (open-output-text-editor t))
+  (displayln "abc" p)
+  (close-output-port p)
+  (test "abc\n" 'wrote-text (send t get-text)))
+
+(let ()
+  (define t (new text%))
+  (define bts1 #"a\302")
+  (define bts2 #"\267 \302\267")
+  (define p (open-output-text-editor t))
+  (write-bytes bts1 p)
+  (flush-output p)
+  (write-bytes bts2 p)
+  (close-output-port p)
+  (test "a· ·" 'unicode-code-point-broken-up (send t get-text)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                            Snips and Streams                               ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/gui-test/tests/gracket/wxme.rkt
+++ b/gui-test/tests/gracket/wxme.rkt
@@ -827,6 +827,24 @@
      (unbox w))
    (send s2 partial-offset dc 0 0 (add1 (string-length str)))))
 
+(let ()
+  (define bts '(#"\360\237\217\264" #"\342\200\215" #"\342\230\240" #"\357\270\217"))
+  (define txt (new text%))
+  (send txt set-styles-sticky #f)
+  (send txt insert "az")
+  (for ([b (in-list bts)]
+        [i (in-naturals)])
+    (send txt insert (bytes->string/utf-8 b)
+          (- (send txt last-position) 1)
+          (- (send txt last-position) 1)
+          #t #t)
+    (when (= i 1)
+      (send txt change-style (make-object style-delta% 'change-bold) 1 2)))
+  (expect (for/list ([i (in-list '(0 1 2 3))])
+            (send txt grapheme-position i))
+          '(0 1 5 6)))
+
+
 ;; ----------------------------------------
 
 ;; Insert very long strings to test max-string-length handling

--- a/gui-test/tests/gracket/wxme.rkt
+++ b/gui-test/tests/gracket/wxme.rkt
@@ -838,7 +838,7 @@
           (- (send txt last-position) 1)
           (- (send txt last-position) 1)
           #t #t)
-    (when (= i 1)
+    (when (= i 0)
       (send txt change-style (make-object style-delta% 'change-bold) 1 2)))
   (expect (for/list ([i (in-list '(0 1 2 3))])
             (send txt grapheme-position i))


### PR DESCRIPTION
…t the bytes that are part of `'aborted` results from the byte coverter and save them for later outside of the pipe, instead of inside of the pipe