### PR TITLE
tex-table: add guillemetleft and guillemetright

### DIFF
--- a/tex-table/tex-table.rkt
+++ b/tex-table/tex-table.rkt
@@ -157,6 +157,8 @@
     ("simeq" "≃")
     ("ll" "≪")
     ("gg" "≫")
+    ("guillemetleft" "«")
+    ("guillemetright" "»")
     ("asymp" "≍")
     ("parallel" "∥")
     ("subset" "⊂")


### PR DESCRIPTION
guillemetleft for `«`, and guillemetright for `»`.

See also https://github.com/racket/scribble/pull/367.

When I try to run it, I get an error message like this:
![guillemet-error](https://github.com/racket/gui/assets/6600123/4f375c54-2505-4d2a-8c70-5a8b510b4829)
