### PR TITLE
Size pref mixin

### DIFF
--- a/gui-doc/scribblings/framework/frame.scrbl
+++ b/gui-doc/scribblings/framework/frame.scrbl
@@ -232,11 +232,11 @@
     height. The preferences key is the one passed
     to the initialization argument of the class.
   }
-  @defmethod[#:mode override (on-move (width position-integer?)
-                                      (height position-integer?))
+  @defmethod[#:mode override (on-move (x position-integer?)
+                                      (y position-integer?))
                     void?]{
-    Updates the preferences according to the width and
-    height, if @racket[position-preferences-key] is not @racket[#f], using
+    Updates the preferences according to the x,y position,
+    if @racket[position-preferences-key] is not @racket[#f], using
     it as the preferences key.
   }
 }

--- a/gui-lib/framework/private/frame.rkt
+++ b/gui-lib/framework/private/frame.rkt
@@ -363,8 +363,8 @@
            (if (and l t mw mh)
                (values (- delta-x l) 
                        (- delta-y t)
-                       (and (<= 0 l mw)
-                            (<= 0 t mh)))
+                       (and (<= l mw)
+                            (<= t mh)))
                (values #f #f #f))]
           [else
            (values #f #f #f)]))


### PR DESCRIPTION
I'm running Ubuntu Linux with two displays. The one on the left is a laptop which I use for terminals and whatnot. Directly in front of me is a larger monitor I use for editing.

I noticed that every time I started `DrRacket` it would show up on the primary (left) screen. After some digging it appeared that the problem was in `frame:size-pref-mixin`. My test program is at the end of this description.

I believe that the issue is due to `get-display-left-top-inset` returning negative numbers in some cases. In this instance the left number is `-1920` per the following trace statement I inserted into `get-sizes/maximzed` when I was figuring this out:
```
mon 1 delta 769 x 307 left -1920 top 0 mon size 1920 x 1080
```

This fails the first `<=` test I that I have changed resulting in the window position always being recalculated. I changed the second one to account for vertical placement of multiple monitors.

With these changes I can turn off the secondary monitor, resulting in the window going to the primary monitor. Turning the secondary monitor back on puts the window back on the secondary monitor. I changed the display configuration to have the primary on the right and it worked there as well. I haven't done *really* extensive testing but the basic mechanism seems to work right except for the two items I have changed so maybe this is sufficient.

This is pretty thorny code and I don't have any Mac or Windows platforms. The two simple changes in this PR make it work for me but it may break code on other platforms.

Demo program is below (`github` apparently won't allow me to attach an `.rkt` file). Run the program then move the window to another monitor and close it. Run the program again. Not sure how to unit test this so I didn't bother.

```
#lang racket

(require racket/gui framework)

(define window-title "Demo Issue")
(define size-prefs 'demo-size-prefs)
(define posn-prefs 'demo-posn-prefs)

(frame:setup-size-pref
 size-prefs 300 100
 #:position-preferences posn-prefs)

(define where-window%
  (class (frame:size-pref-mixin
          (frame:basic-mixin
           frame%))
    (super-new
     [label window-title]
     [size-preferences-key size-prefs]
     [position-preferences-key posn-prefs])

    (define/override (on-size width height)
      (super on-size width height))

    (define/override (on-move x y)
      (super on-move x y))))

(let ([new-es 
       (make-eventspace)])
  (parameterize ([current-eventspace new-es])
    (let ([f (new where-window%)])
      (send f show #t))))
```

I also noticed a very minor documentation error that should be self-explanatory.