### PR TITLE
message: handle invalid colors under cocoa and gtk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,22 @@ on: [push, pull_request]
 
 jobs:
   build-test:
-    runs-on: ubuntu-18.04
+    name: Build & Test (Racket ${{ matrix.variant }})
+    runs-on: ubuntu-latest
     container: racket/racket-ci:latest
 
     strategy:
       fail-fast: false
       matrix:
-        vm: ['BC', 'CS']
+        variant: ['BC', 'CS']
 
     steps:
     - uses: actions/checkout@master
-    - uses: Bogdanp/setup-racket@v1.8.1
+    - uses: Bogdanp/setup-racket@v1.10
       with:
         architecture: 'x64'
         distribution: 'minimal'
-        variant: ${{ matrix.vm }}
+        variant: ${{ matrix.variant }}
         version: 'current'
     - name: Install and setup
       run: |

--- a/gui-doc/scribblings/gui/message-class.scrbl
+++ b/gui-doc/scribblings/gui/message-class.scrbl
@@ -77,12 +77,16 @@ Otherwise, sets the bitmap label for a bitmap message.
 
 }
 
-@defmethod*[([(set-color [color (is-a?/c color%)]) void?]
+@defmethod*[([(set-color [color (or/c #f (is-a?/c color%))]) void?]
              [(set-color [color-name string?]) void?])]{
-  Sets the label's text color.  This method has no effect if the label
-  is a symbol or a bitmap.
+  Sets the label's text color. When @racket[color] is @racket[#f], sets
+  the label's text color to the platform default. This method has no
+  effect if the label is a symbol or a bitmap.
 
-  @history[#:added "1.58"]
+  @history[
+    #:added "1.58"
+    #:changed "1.71" @elem{Added support for setting the color to the system default.}
+  ]
 }
 
 @defmethod[(get-color) (or/c #f (is-a?/c color%))]{

--- a/gui-lib/info.rkt
+++ b/gui-lib/info.rkt
@@ -34,7 +34,7 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.70")
+(define version "1.71")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/gui-lib/mred/private/wx/cocoa/color.rkt
+++ b/gui-lib/mred/private/wx/cocoa/color.rkt
@@ -2,12 +2,19 @@
 
 (require ffi/unsafe/objc
          racket/draw/private/color
-         "types.rkt")
+         "types.rkt"
+         "utils.rkt")
 
 (provide
+ get-default-label-color
  color->NSColor)
 
 (import-class NSColor)
+
+(define (get-default-label-color)
+  (if (version-10.10-or-later?)
+      (tell NSColor labelColor)
+      (tell NSColor controlTextColor)))
 
 (define (color->NSColor c)
   (tell NSColor

--- a/gui-lib/mred/private/wx/cocoa/message.rkt
+++ b/gui-lib/mred/private/wx/cocoa/message.rkt
@@ -134,6 +134,8 @@
   (define/public (set-color c)
     (when text-label?
       (set! color c)
-      (tellv (get-cocoa) setTextColor: (color->NSColor c))))
+      (tellv (get-cocoa) setTextColor: (if c
+                                           (color->NSColor c)
+                                           (get-default-label-color)))))
 
   (def/public-unimplemented get-font))

--- a/gui-lib/mred/private/wx/gtk/message.rkt
+++ b/gui-lib/mred/private/wx/gtk/message.rkt
@@ -45,15 +45,16 @@
 
 (define (do-set-label-color label c)
   (define attrs (pango_attr_list_new))
-  (define color-attr (pango_attr_foreground_new
-                      (color-component->gtk (color-red c))
-                      (color-component->gtk (color-green c))
-                      (color-component->gtk (color-blue c))))
-  (define color-alpha-attr (pango_attr_foreground_alpha_new
-                            (color-component->gtk (* (color-alpha c) 255))))
-  (pango_attr_list_insert attrs color-attr)
-  (when color-alpha-attr
-    (pango_attr_list_insert attrs color-alpha-attr))
+  (when c
+    (define color-attr (pango_attr_foreground_new
+                        (color-component->gtk (color-red c))
+                        (color-component->gtk (color-green c))
+                        (color-component->gtk (color-blue c))))
+    (define color-alpha-attr (pango_attr_foreground_alpha_new
+                              (color-component->gtk (* (color-alpha c) 255))))
+    (pango_attr_list_insert attrs color-attr)
+    (when color-alpha-attr
+      (pango_attr_list_insert attrs color-alpha-attr)))
   (gtk_label_set_attributes label attrs))
 
 (defclass message% item%


### PR DESCRIPTION
Changes `message%` cocoa and gtk wxs to reset messages to the default color when set to an invalid color or `#f`. The win32 implementation already behaves this way.

Fixes #307

~~Draft while I set up a Linux VM to test the change there also.~~