### PR TITLE
update the focus when deleting a snip that has the focus

### DIFF
--- a/gui-lib/mred/private/wxme/text.rkt
+++ b/gui-lib/mred/private/wxme/text.rkt
@@ -2025,8 +2025,10 @@
                                                         (let ([rl? read-locked?])
                                                           (set! read-locked? #t)
                                                           (send s-caret-snip own-caret #f)
+                                                          (do-own-caret #t)
                                                           (set! read-locked? rl?)
                                                           (set! s-caret-snip #f)
+                                                          (on-focus #t)
                                                           #t))
                                                    update-cursor?)])
                                           


### PR DESCRIPTION
This fixes a bug that was found [on discourse](https://racket.discourse.group/t/uncommenting-does-not-work-on-any-linux-distro-with-gnome-3/1299/6).