### PR TITLE
cocoa,canvas: fix bezel-cell frame for FocusView

### DIFF
--- a/gui-lib/mred/private/wx/cocoa/canvas.rkt
+++ b/gui-lib/mred/private/wx/cocoa/canvas.rkt
@@ -145,16 +145,16 @@
   (tell (tell NSTextFieldCell alloc) initTextCell: #:type _NSString ""))
 (tellv bezel-cell setBezeled: #:type _BOOL #t)
 
-(define-objc-class FocusView NSView 
+(define-objc-class FocusView NSView
   [on?]
   (-a _void (setFocusState: [_BOOL is-on?])
       (set! on? is-on?))
   (-a #:async-apply (box (void))
       _void (drawRect: [_NSRect r])
       (let ([f (tell #:type _NSRect self frame)])
-        (tellv bezel-cell 
+        (tellv bezel-cell
                drawWithFrame: #:type _NSRect (make-NSRect (make-NSPoint 2 2)
-                                                          (let ([s (NSRect-size r)])
+                                                          (let ([s (NSRect-size f)])
                                                             (make-NSSize (- (NSSize-width s) 4)
                                                                          (- (NSSize-height s) 4))))
                inView: self))


### PR DESCRIPTION
Fixes #325. The `r` argument represents the portion of the view that is "dirty", and it seems like it may be larger than the view's frame[1]. It looks like this code was already intending to use the view's frame to draw the bezel, but accidentally used the dirty rect instead.

[1]: At least on recent versions of macOS, which may explain why [this isn't a problem when using versions of Racket built on older macOS versions](https://github.com/racket/drracket/issues/652#issuecomment-1853144763).