### PR TITLE
Fix #336: Disable asynchronous mode for GTK printing.

### DIFF
--- a/gui-lib/mred/private/wx/gtk/printer-dc.rkt
+++ b/gui-lib/mred/private/wx/gtk/printer-dc.rkt
@@ -165,7 +165,7 @@
     (connect-end-print op-gtk)
 
     (gtk_print_operation_set_n_pages op-gtk (length pages))
-    (gtk_print_operation_set_allow_async op-gtk #t)
+    (gtk_print_operation_set_allow_async op-gtk #f)
     (gtk_print_operation_set_default_page_setup op-gtk page-setup)
 
     (define done-sema (make-semaphore))


### PR DESCRIPTION
Fix issue #336: for unknown reasons, asynchronous printing in GTK3 generates blank pages.  Disabling asynchronous mode fixes this problem.  This change makes the main window freeze when the print dialog is popped up.  But it shouldn't be a problem.  First this is also the default behavior when the print dialog is popped up in Windows.  This change makes the behavior more consistent on different OSes.  Besides, it is reasonable to forbid editing when the contents of the editor is being printed.