### PR TITLE
Update resyntax-autofixer.yml

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -24,7 +24,7 @@ jobs:
           sudo: never
       - name: Install and setup
         run: |
-          raco pkg install -i --auto --no-setup --skip-installed gui-test
+          raco pkg install -i --auto --no-setup --skip-installed gui-test gui-doc
           raco pkg update --auto --no-setup gui-doc gui-lib gui tex-table
           raco setup gui-doc gui-lib gui-test gui tex-table
       - name: Create a Resyntax pull request


### PR DESCRIPTION
The `gui-doc` package is not installed in the docker container the action is using, so it has to be installed and then updated rather than just updated.