### PR TITLE
wayland: Set framebuffer scale when creating an OpenGL context

### DIFF
--- a/gui-lib/mred/private/wx/gtk/gl-context.rkt
+++ b/gui-lib/mred/private/wx/gtk/gl-context.rkt
@@ -422,7 +422,8 @@
 
     (define/public (gl-update-size x y w h)
       (when win
-	(wl_egl_window_resize win w h 0 0)
+	(define scale (if widget (gtk_widget_get_scale_factor widget) 1))
+	(wl_egl_window_resize win (* scale w) (* scale h) 0 0)
 	(when (and widget wl-subsurface)
 	  (define toplevel (gtk_widget_get_toplevel widget))
 	  (define-values (dx dy)
@@ -702,10 +703,11 @@
 				     (error 'EGL "subcompositor failed")))
 
 	(define (create recreate?)
+	  (define scale (gtk_widget_get_scale_factor widget))
 	  (define-values (width height)
 	    (let ([a (widget-allocation widget)])
-	      (values (GtkAllocation-width a)
-		      (GtkAllocation-height a))))
+              (values (* scale (GtkAllocation-width a))
+                      (* scale (GtkAllocation-height a)))))
 
 	  (define wl-surface/sub (or (wayland-compositor-create-surface wl-compositor)
 				     (error 'EGL "subsurface create failed")))
@@ -728,6 +730,7 @@
 	      (wayland-region-destroy region))
 	    (wayland-subsurface-set-position wl-subsurface dx dy)
 	    (wayland-subsurface-set-sync wl-subsurface #f)
+	    (wayland-surface-set-buffer-scale wl-surface/sub scale)
 	    (wayland-surface-commit wl-surface/sub)
 	    (wayland-surface-commit wl-surface))
 

--- a/gui-lib/mred/private/wx/gtk/wayland.rkt
+++ b/gui-lib/mred/private/wx/gtk/wayland.rkt
@@ -12,6 +12,7 @@
 	 wayland-subsurface-set-position
 	 wayland-subsurface-set-sync
 	 wayland-surface-commit
+         wayland-surface-set-buffer-scale
 	 wayland-surface-destroy
 	 wayland-roundtrip
 	 wayland-display-dispatch-pending
@@ -62,6 +63,7 @@
 (define WL_SURFACE_FRAME 3)
 (define WL_SURFACE_SET_INPUT_REGION 5)
 (define WL_SURFACE_COMMIT 6)
+(define WL_SURFACE_SET_BUFFER_SCALE 8)
 (define WL_REGION_DESTROY 0)
 
 (define _registry (_cpointer/null 'wl_registry))
@@ -129,6 +131,14 @@
   (_fun #:varargs-after 5
 	_pointer _uint32 _pointer _uint32
 	_uint32
+	-> _pointer
+	-> (void))
+  #:c-id wl_proxy_marshal_flags)
+(define-wayland wl_proxy_marshal_flags/wl_surface_set_buffer_scale
+  (_fun #:varargs-after 5
+	_pointer _uint32 _pointer _uint32
+	_uint32
+	_int32
 	-> _pointer
 	-> (void))
   #:c-id wl_proxy_marshal_flags)
@@ -225,6 +235,14 @@
    WL_SURFACE_COMMIT
    #f (wl_proxy_get_version surface)
    0))
+
+(define (wayland-surface-set-buffer-scale surface scale)
+  (wl_proxy_marshal_flags/wl_surface_set_buffer_scale
+   surface
+   WL_SURFACE_SET_BUFFER_SCALE
+   #f (wl_proxy_get_version surface)
+   0
+   scale))
 
 (define (wayland-surface-destroy surface)
   (wl_proxy_marshal_flags/wl_<object>_destroy


### PR DESCRIPTION
Currently, on Wayland, creating an OpenGL context does not work as intended when high-DPI display scaling is enabled. Under such a configuration `get-gl-client-size` will return scaled values (which is correct), but the framebuffer will be created with the unscaled values, resulting in a low-resolution render that is scaled up by the compositor. Additionally, passing the results of `get-gl-client-size` to `glViewport` will result in only a portion of the frame being rendered, which is inconsistent with other platforms.

This PR fixes the issue by explicitly setting the framebuffer scale when creating the Wayland surface. I have tested on my machine and confirmed that it resolves the problem, but I am unfortunately not sure how to write a test case for this change, as I don’t think there is any way to observe the difference from within the Racket program.