### PR TITLE
mrlib/gif: don't depend on racket/gui/base

### DIFF
--- a/gui-lib/mrlib/gif.rkt
+++ b/gui-lib/mrlib/gif.rkt
@@ -2,7 +2,7 @@
 
 ;; A library for creating gifs out of bitmap%s
 
-(require racket/gui/base
+(require racket/draw
          racket/class
          racket/list
          net/gifwrite


### PR DESCRIPTION
The only identifier it had been importing from `racket/gui/base` was `bitmap%`, which can be imported from `racket/draw` instead.